### PR TITLE
Settings in tab view, contextmenus, and color fixes

### DIFF
--- a/Shared/Extensions/UIImageColors.swift
+++ b/Shared/Extensions/UIImageColors.swift
@@ -200,7 +200,7 @@ extension UIImage {
                     return nil
                 }
                 let result = NSImage(size: newSize, flipped: false, drawingHandler: { _ -> Bool in
-                    return representation.draw(in: frame)
+                    representation.draw(in: frame)
                 })
 
                 return result

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Aidoku needs permission to save pages in your photo library</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/iOS/SceneDelegate.swift
+++ b/iOS/SceneDelegate.swift
@@ -16,10 +16,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let libraryViewController = UINavigationController(rootViewController: LibraryViewController())
         let browseViewController = UINavigationController(rootViewController: BrowseViewController())
         let searchViewController = UINavigationController(rootViewController: SearchViewController())
+        let settingsViewController = UINavigationController(rootViewController: SettingsViewController())
         libraryViewController.tabBarItem = UITabBarItem(title: "Library", image: UIImage(systemName: "books.vertical.fill"), tag: 0)
         browseViewController.tabBarItem = UITabBarItem(title: "Browse", image: UIImage(systemName: "globe"), tag: 1)
         searchViewController.tabBarItem = UITabBarItem(title: "Search", image: UIImage(systemName: "magnifyingglass"), tag: 2)
-        tabController.viewControllers = [libraryViewController, browseViewController, searchViewController]
+        settingsViewController.tabBarItem = UITabBarItem(title: "Settings", image: UIImage(systemName: "gear"), tag: 3)
+        tabController.viewControllers = [libraryViewController, browseViewController, searchViewController, settingsViewController]
 
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)

--- a/iOS/UI/Base/MangaListSelectionHeader.swift
+++ b/iOS/UI/Base/MangaListSelectionHeader.swift
@@ -20,7 +20,7 @@ class MangaListSelectionHeader: UICollectionReusableView {
 
     let filterButton = UIButton(type: .roundedRect)
 
-    var title: String? = nil {
+    var title: String? {
         didSet {
             titleLabel.text = title
         }

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -40,13 +40,6 @@ class LibraryViewController: MangaCollectionViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.hidesSearchBarWhenScrolling = false
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            image: UIImage(systemName: "gear"),
-            style: .plain,
-            target: self,
-            action: #selector(showSettings)
-        )
-
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = self
         searchController.obscuresBackgroundDuringPresentation = false
@@ -132,12 +125,6 @@ class LibraryViewController: MangaCollectionViewController {
     func fetchLibrary() {
         manga = DataManager.shared.libraryManga
         reloadData()
-    }
-
-    @objc func showSettings() {
-        let settingsController = UINavigationController(rootViewController: SettingsViewController())
-        settingsController.presentationController?.delegate = self
-        present(settingsController, animated: true)
     }
 }
 

--- a/iOS/UI/Reader/Page/ReaderInfoPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderInfoPageView.swift
@@ -16,12 +16,12 @@ class ReaderInfoPageView: UIView {
     var type: ReaderInfoPageType
 
     let currentChapter: Chapter
-    var previousChapter: Chapter? = nil {
+    var previousChapter: Chapter? {
         didSet {
             updateLabelText()
         }
     }
-    var nextChapter: Chapter? = nil {
+    var nextChapter: Chapter? {
         didSet {
             updateLabelText()
         }

--- a/iOS/UI/Reader/Page/ReaderInfoPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderInfoPageView.swift
@@ -41,7 +41,7 @@ class ReaderInfoPageView: UIView {
 
         super.init(frame: .zero)
 
-        backgroundColor = .white
+        backgroundColor = .systemBackground
 
         stackView.distribution = .equalSpacing
         stackView.axis = .vertical
@@ -52,9 +52,9 @@ class ReaderInfoPageView: UIView {
         topStackView.distribution = .equalSpacing
         topStackView.axis = .vertical
         topStackView.spacing = 2
-        topChapterLabel.textColor = .black
+        topChapterLabel.textColor = .label
         topChapterLabel.font = .systemFont(ofSize: 16, weight: .medium)
-        topChapterTitleLabel.textColor = .gray
+        topChapterTitleLabel.textColor = .secondaryLabel
         topChapterTitleLabel.font = .systemFont(ofSize: 16)
         topChapterTitleLabel.numberOfLines = 0
 
@@ -62,9 +62,9 @@ class ReaderInfoPageView: UIView {
         bottomStackView.distribution = .equalSpacing
         bottomStackView.axis = .vertical
         bottomStackView.spacing = 2
-        bottomChapterLabel.textColor = .black
+        bottomChapterLabel.textColor = .label
         bottomChapterLabel.font = .systemFont(ofSize: 16, weight: .medium)
-        bottomChapterTitleLabel.textColor = .gray
+        bottomChapterTitleLabel.textColor = .secondaryLabel
         bottomChapterTitleLabel.font = .systemFont(ofSize: 16)
         bottomChapterTitleLabel.numberOfLines = 0
 
@@ -78,7 +78,7 @@ class ReaderInfoPageView: UIView {
 
         addSubview(stackView)
 
-        noChapterLabel.textColor = .gray
+        noChapterLabel.textColor = .secondaryLabel
         noChapterLabel.textAlignment = .center
         noChapterLabel.font = .systemFont(ofSize: 16)
         noChapterLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -444,6 +444,11 @@ extension ReaderViewController {
             for _ in self.pages {
                 let pageView = ReaderPageView()
                 pageView.translatesAutoresizingMaskIntoConstraints = false
+
+                // Append context menu interaction for each page in the chapter
+                let interaction = UIContextMenuInteraction(delegate: self)
+                pageView.imageView.addInteraction(interaction)
+
                 self.items.append(pageView)
             }
 
@@ -632,5 +637,23 @@ extension ReaderViewController: UIPopoverPresentationControllerDelegate {
     func adaptivePresentationStyle(for controller: UIPresentationController,
                                    traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         .none
+    }
+}
+
+// MARK: - Context menu Delegate
+extension ReaderViewController: UIContextMenuInteractionDelegate {
+    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: { _ in
+            let saveToPhotosAction = UIAction(title: "Save to Photos", image: UIImage(systemName: "square.and.arrow.down")) { [self] _ in
+                if let currentPage: ReaderPageView = items[currentIndex + 1 + hasPreviousChapter.intValue] as? ReaderPageView {
+                    if let image = currentPage.imageView.image {
+                        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+                    }
+                }
+            }
+
+            return UIMenu(title: "", children: [saveToPhotosAction])
+        })
     }
 }

--- a/iOS/UI/Search/SearchViewController.swift
+++ b/iOS/UI/Search/SearchViewController.swift
@@ -12,7 +12,7 @@ class MangaCarouselHeader: UICollectionReusableView {
     let titleLabel = UILabel()
     let viewMoreButton = UIButton(type: .roundedRect)
 
-    var title: String? = nil {
+    var title: String? {
         didSet {
             titleLabel.text = title
         }

--- a/iOS/UI/Settings/SettingsViewController.swift
+++ b/iOS/UI/Settings/SettingsViewController.swift
@@ -80,12 +80,6 @@ class SettingsViewController: UITableViewController {
         title = "Settings"
         navigationController?.navigationBar.prefersLargeTitles = true
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(close)
-        )
-
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = 0
         }
@@ -105,10 +99,6 @@ class SettingsViewController: UITableViewController {
 
         alertView.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         present(alertView, animated: true)
-    }
-
-    @objc func close() {
-        dismiss(animated: true)
     }
 }
 


### PR DESCRIPTION
This PR adds some fixes and features to Aidoku:
- Settings has been moved from library into its own tab for easy access
- A ContextMenu has been added to save the current page to a user's photo gallery (can present a share sheet in the future)
- Color schemes have been fixed for the in-between page for chapters
