### PR TITLE
Various fixes for v0.2

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C807DDD27D47C2D0042EE7B /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C807DDC27D47C2D0042EE7B /* CircularProgressView.swift */; };
 		FB11EDEF2784B0690007365D /* Volume.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB11EDEE2784B0690007365D /* Volume.swift */; };
 		FB11EDF02784B0690007365D /* Volume.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB11EDEE2784B0690007365D /* Volume.swift */; };
 		FB1B483E277CE1920056D02C /* Aidoku.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FB1B482B277CE18D0056D02C /* Aidoku.xcdatamodeld */; };
@@ -127,6 +128,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0C807DDC27D47C2D0042EE7B /* CircularProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		FB11EDEE2784B0690007365D /* Volume.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Volume.swift; sourceTree = "<group>"; };
 		FB1B482C277CE18D0056D02C /* Shared.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Shared.xcdatamodel; sourceTree = "<group>"; };
 		FB1B482D277CE18D0056D02C /* AidokuApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AidokuApp.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				FBFA43AC2799DD110065A445 /* ReaderSliderView.swift */,
 				FB5FB5F52794EBD60059632B /* ChapterListPopoverContentController.swift */,
 				FB1B48B6277CF8280056D02C /* ZoomableScrollView.swift */,
+				0C807DDC27D47C2D0042EE7B /* CircularProgressView.swift */,
 			);
 			path = Reader;
 			sourceTree = "<group>";
@@ -704,6 +707,7 @@
 				FB7B7ECD2789EAE6001E6EAF /* WasmMemory.swift in Sources */,
 				FB72501C27CAACC00037F1C9 /* BackupChapter.swift in Sources */,
 				FB4EEBC427A34ED4005081A3 /* ChapterObject.swift in Sources */,
+				0C807DDD27D47C2D0042EE7B /* CircularProgressView.swift in Sources */,
 				FBFA43AD2799DD110065A445 /* ReaderSliderView.swift in Sources */,
 				FBED232927BDF4C90095D0C0 /* TextInputTableViewCell.swift in Sources */,
 				FB72501927CAACB70037F1C9 /* BackupLibraryManga.swift in Sources */,

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -19,6 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "General.appearance": 0,
                 "General.useSystemAppearance": true,
 
+                "Reader.downsampleImages": true,
+
                 "Library.opensReaderView": false,
                 "Library.unreadChapterBadges": true,
 

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,6 +29,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Browse.labelNsfwSources": true
             ]
         )
+
+        KingfisherManager.shared.cache.memoryStorage.config.totalCostLimit = 300 * 1024 * 1024
+        KingfisherManager.shared.cache.memoryStorage.config.countLimit = 150
 
         return true
     }

--- a/iOS/UI/Reader/CircularProgressView.swift
+++ b/iOS/UI/Reader/CircularProgressView.swift
@@ -1,0 +1,72 @@
+//
+//  CircularProgressView.swift
+//  Aidoku (iOS)
+//
+//  Created by Brian Dashore on 3/5/22.
+//
+//  Based off of: https://github.com/leoiphonedev/CircularProgressView-Tutorial
+
+import UIKit
+
+class CircularProgressView: UIView {
+    // You can set this value directly, but it's better to use setProgress
+    var progress: CGFloat = 0 {
+        didSet(newValue) {
+            progressLayer.strokeEnd = newValue
+        }
+    }
+
+    private var progressLayer = CAShapeLayer()
+    private var trackLayer = CAShapeLayer()
+
+    var progressColor = UIColor.white {
+        didSet(newValue) {
+            progressLayer.strokeColor = newValue.cgColor
+        }
+    }
+    var trackColor = UIColor.white {
+        didSet(newValue) {
+            trackLayer.strokeColor = newValue.cgColor
+        }
+    }
+    var lineWidth: CGFloat = 3
+
+    override func draw(_ rect: CGRect) {
+        self.backgroundColor = UIColor.clear
+        self.layer.cornerRadius = self.frame.size.width / 2
+
+        let circlePath = UIBezierPath(
+            arcCenter: CGPoint(x: frame.size.width / 2, y: frame.size.height / 2),
+            radius: (frame.size.width - 1.5) / 2,
+            startAngle: -0.5 * .pi,
+            endAngle: CGFloat(1.5 * .pi),
+            clockwise: true)
+
+        trackLayer.path = circlePath.cgPath
+        trackLayer.fillColor = UIColor.clear.cgColor
+        trackLayer.strokeColor = trackColor.cgColor
+        trackLayer.lineWidth = lineWidth
+        trackLayer.strokeEnd = 1
+        layer.addSublayer(trackLayer)
+
+        progressLayer.path = circlePath.cgPath
+        progressLayer.fillColor = UIColor.clear.cgColor
+        progressLayer.strokeColor = progressColor.cgColor
+        progressLayer.lineWidth = lineWidth
+        progressLayer.strokeEnd = progress
+        layer.addSublayer(progressLayer)
+    }
+
+    func setProgress(value: Float, withAnimation: Bool) {
+        if withAnimation {
+            let endAnimation = CABasicAnimation(keyPath: "strokeEnd")
+            endAnimation.duration = 1
+            endAnimation.fromValue = 0
+            endAnimation.toValue = value
+            endAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
+            progressLayer.add(endAnimation, forKey: "animateProgress")
+        }
+
+        progress = CGFloat(value)
+    }
+}

--- a/iOS/UI/Reader/CircularProgressView.swift
+++ b/iOS/UI/Reader/CircularProgressView.swift
@@ -15,6 +15,13 @@ class CircularProgressView: UIView {
             progressLayer.strokeEnd = newValue
         }
     }
+    private var oldProgress: Float = 0 {
+        didSet(newValue) {
+            if newValue >= 1 {
+                oldProgress = 0
+            }
+        }
+    }
 
     private var progressLayer = CAShapeLayer()
     private var trackLayer = CAShapeLayer()
@@ -58,6 +65,10 @@ class CircularProgressView: UIView {
     }
 
     func setProgress(value: Float, withAnimation: Bool) {
+        if value < oldProgress || value > 1 {
+            return
+        }
+
         if withAnimation {
             let endAnimation = CABasicAnimation(keyPath: "strokeEnd")
             endAnimation.duration = 1
@@ -68,5 +79,6 @@ class CircularProgressView: UIView {
         }
 
         progress = CGFloat(value)
+        oldProgress = value
     }
 }

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -94,17 +94,21 @@ class ReaderPageView: UIView {
         currentUrl = url
 
         DispatchQueue.main.async {
-            let processor = DownsamplingImageProcessor(size: UIScreen.main.bounds.size)
             let retry = DelayRetryStrategy(maxRetryCount: 2, retryInterval: .seconds(0.1))
+            var kfOptions: [KingfisherOptionsInfoItem] = [
+                .scaleFactor(UIScreen.main.scale),
+                .transition(.fade(0.3)),
+                .retryStrategy(retry)
+            ]
+
+            if UserDefaults.standard.bool(forKey: "Reader.downsampleImages") {
+                let downsampleProcessor = DownsamplingImageProcessor(size: UIScreen.main.bounds.size)
+                kfOptions += [.processor(downsampleProcessor), .cacheOriginalImage]
+            }
+
             self.imageView.kf.setImage(
                 with: URL(string: url),
-                options: [
-                    .cacheOriginalImage,
-                    .processor(processor),
-                    .scaleFactor(UIScreen.main.scale),
-                    .transition(.fade(0.3)),
-                    .retryStrategy(retry)
-                ]
+                options: kfOptions
             ) { result in
                 switch result {
                 case .success:

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -10,7 +10,7 @@ import Kingfisher
 
 class ReaderPageView: UIView {
 
-    var zoomableView = ZoomableScrollView(frame: .zero)
+    var zoomableView = ZoomableScrollView(frame: UIScreen.main.bounds)
     let imageView = UIImageView()
     let activityIndicator = UIActivityIndicatorView(style: .medium)
     let reloadButton = UIButton(type: .roundedRect)

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -115,7 +115,7 @@ class ReaderViewController: UIViewController {
     let sliderView = ReaderSliderView()
     let currentPageLabel = UILabel()
     let pagesLeftLabel = UILabel()
-    let activityIndicator = UIActivityIndicatorView(style: .medium)
+    let progressView = CircularProgressView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
 
     var toolbarSliderWidthConstraint: NSLayoutConstraint?
 
@@ -146,7 +146,7 @@ class ReaderViewController: UIViewController {
         self.chapter = chapter
         self.startPage = 0
         self.chapterList = chapterList
-        self.scrollView = UIScrollView()
+        self.scrollView = UIScrollView(frame: UIScreen.main.bounds)
         self.savedStandardAppearance = UINavigationBar.appearance().standardAppearance
         super.init(nibName: nil, bundle: nil)
     }
@@ -249,10 +249,12 @@ class ReaderViewController: UIViewController {
         transitionView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(transitionView)
 
-        activityIndicator.startAnimating()
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        items.append(activityIndicator)
-        scrollView.addSubview(activityIndicator)
+        // TODO: Maybe make this an indefinite progress view
+        progressView.center = scrollView.center
+        progressView.trackColor = .quaternaryLabel
+        progressView.progressColor = scrollView.tintColor
+        items.append(progressView)
+        scrollView.addSubview(progressView)
 
         view.addGestureRecognizer(singleTap)
 
@@ -284,9 +286,6 @@ class ReaderViewController: UIViewController {
 
         transitionView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
         transitionView.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
-
-        activityIndicator.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor).isActive = true
-        activityIndicator.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor).isActive = true
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/iOS/UI/Settings/SettingsViewController.swift
+++ b/iOS/UI/Settings/SettingsViewController.swift
@@ -24,6 +24,9 @@ class SettingsViewController: SettingsTableViewController {
                             values: ["Light", "Dark"], requiresFalse: "General.useSystemAppearance"),
                 SettingItem(type: "switch", key: "General.useSystemAppearance", title: "Use System Appearance")
             ]),
+            SettingItem(type: "group", title: "Reader", items: [
+                SettingItem(type: "switch", key: "Reader.downsampleImages", title: "Downsample Images")
+            ]),
             SettingItem(type: "group", title: "Library", items: [
                 SettingItem(type: "switch", key: "Library.opensReaderView", title: "Open Reader View"),
                 SettingItem(type: "switch", key: "Library.unreadChapterBadges", title: "Unread Chapter Badges")


### PR DESCRIPTION
The changelog is as follows:
- Fix the black screen bug that was appearing in the reader (after fixing the reload bug)
- Add the option to downsample images in settings (can be moved inside the reader later on)
- Add a circular progress bar instead of apple's progress spinner
- Set memory limits for kingfisher so 25% of a user's resources isn't used up