### PR TITLE
Add Github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+name: Build and upload nightly ipa
+
+on: [ push, workflow_dispatch ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Get commit SHA
+        id: commitinfo
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Build
+        run: xcodebuild -scheme "Aidoku (iOS)" -configuration Release archive -archivePath build/Aidoku.xcarchive CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+      - name: Package ipa
+        run: |
+          mkdir Payload
+          cp -r build/Aidoku.xcarchive/Products/Applications/Aidoku.app Payload
+          zip -r Aidoku-iOS_nightly-${{ steps.commitinfo.outputs.sha_short }}.ipa Payload
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Aidoku-iOS_nightly-${{ steps.commitinfo.outputs.sha_short }}.ipa
+          path: Aidoku-iOS_nightly-${{ steps.commitinfo.outputs.sha_short }}.ipa
+          if-no-files-found: error


### PR DESCRIPTION
Add nightly builds to be posted on the Github. These are considered as development builds and anyone who does sideload them uses them at their own risk.

Highly recommend a backup!

But it's still a good idea to have nightlies for users who want features now.