### PR TITLE
Add getting an element's own text and data to WasmHtml

### DIFF
--- a/Shared/Wasm/Imports/WasmHtml.swift
+++ b/Shared/Wasm/Imports/WasmHtml.swift
@@ -204,7 +204,7 @@ extension WasmHtml {
             return -1
         }
     }
-    
+
     var ownText: (Int32) -> Int32 {
         { descriptor in
             guard descriptor >= 0 else { return -1 }

--- a/Shared/Wasm/Imports/WasmHtml.swift
+++ b/Shared/Wasm/Imports/WasmHtml.swift
@@ -34,6 +34,7 @@ class WasmHtml {
         try? globalStore.vm.addImportHandler(named: "base_uri", namespace: namespace, block: self.baseUri)
         try? globalStore.vm.addImportHandler(named: "body", namespace: namespace, block: self.select)
         try? globalStore.vm.addImportHandler(named: "text", namespace: namespace, block: self.text)
+        try? globalStore.vm.addImportHandler(named: "own_text", namespace: namespace, block: self.ownText)
         try? globalStore.vm.addImportHandler(named: "array", namespace: namespace, block: self.array)
         try? globalStore.vm.addImportHandler(named: "html", namespace: namespace, block: self.html)
         try? globalStore.vm.addImportHandler(named: "outer_html", namespace: namespace, block: self.outerHtml)
@@ -196,6 +197,20 @@ extension WasmHtml {
             if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Elements)?.text() {
                 return self.globalStore.storeStdValue(string, from: descriptor)
             } else if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.text() {
+                return self.globalStore.storeStdValue(string, from: descriptor)
+            } else if let string = self.globalStore.readStdValue(descriptor) as? String {
+                return self.globalStore.storeStdValue(string, from: descriptor)
+            }
+            return -1
+        }
+    }
+    
+    var ownText: (Int32) -> Int32 {
+        { descriptor in
+            guard descriptor >= 0 else { return -1 }
+            if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Elements)?.ownText() {
+                return self.globalStore.storeStdValue(string, from: descriptor)
+            } else if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.ownText() {
                 return self.globalStore.storeStdValue(string, from: descriptor)
             } else if let string = self.globalStore.readStdValue(descriptor) as? String {
                 return self.globalStore.storeStdValue(string, from: descriptor)

--- a/Shared/Wasm/Imports/WasmHtml.swift
+++ b/Shared/Wasm/Imports/WasmHtml.swift
@@ -208,9 +208,7 @@ extension WasmHtml {
     var ownText: (Int32) -> Int32 {
         { descriptor in
             guard descriptor >= 0 else { return -1 }
-            if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Elements)?.ownText() {
-                return self.globalStore.storeStdValue(string, from: descriptor)
-            } else if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.ownText() {
+            if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.ownText() {
                 return self.globalStore.storeStdValue(string, from: descriptor)
             } else if let string = self.globalStore.readStdValue(descriptor) as? String {
                 return self.globalStore.storeStdValue(string, from: descriptor)

--- a/Shared/Wasm/Imports/WasmHtml.swift
+++ b/Shared/Wasm/Imports/WasmHtml.swift
@@ -35,6 +35,7 @@ class WasmHtml {
         try? globalStore.vm.addImportHandler(named: "body", namespace: namespace, block: self.select)
         try? globalStore.vm.addImportHandler(named: "text", namespace: namespace, block: self.text)
         try? globalStore.vm.addImportHandler(named: "own_text", namespace: namespace, block: self.ownText)
+        try? globalStore.vm.addImportHandler(named: "data", namespace: namespace, block: self.data)
         try? globalStore.vm.addImportHandler(named: "array", namespace: namespace, block: self.array)
         try? globalStore.vm.addImportHandler(named: "html", namespace: namespace, block: self.html)
         try? globalStore.vm.addImportHandler(named: "outer_html", namespace: namespace, block: self.outerHtml)
@@ -209,6 +210,18 @@ extension WasmHtml {
         { descriptor in
             guard descriptor >= 0 else { return -1 }
             if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.ownText() {
+                return self.globalStore.storeStdValue(string, from: descriptor)
+            } else if let string = self.globalStore.readStdValue(descriptor) as? String {
+                return self.globalStore.storeStdValue(string, from: descriptor)
+            }
+            return -1
+        }
+    }
+
+    var data: (Int32) -> Int32 {
+        { descriptor in
+            guard descriptor >= 0 else { return -1 }
+            if let string = try? (self.globalStore.readStdValue(descriptor) as? SwiftSoup.Element)?.data() {
                 return self.globalStore.storeStdValue(string, from: descriptor)
             } else if let string = self.globalStore.readStdValue(descriptor) as? String {
                 return self.globalStore.storeStdValue(string, from: descriptor)


### PR DESCRIPTION
`Element.ownText()` returns text owned by this element, without combining children's texts. For example:

```
<div class="col-md-4">
    17 May. 2022
    <a href="https://mega.nz/file/6ewVEJzL#iIk392r2k7bxCV8CAwa44OO8zuLrrY2sHgNQBf4uIn4" class="btn btn-primary btn-xs download">Download</a>
</div>
```

`div.ownText()` would return only `17 May. 2022` instead of `17 May. 2022 Download`.

----
`Element.data()` is for getting data inside a `<script>` tag.