### PR TITLE
Switch backups to binary plists

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,8 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+      - name: Setup build cache
+        uses: mikehardy/buildcache-action@v1
       - name: Get commit SHA
         id: commitinfo
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -17,7 +17,13 @@ jobs:
         id: commitinfo
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Build
-        run: xcodebuild -scheme "Aidoku (iOS)" -configuration Release archive -archivePath build/Aidoku.xcarchive CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        run: |
+          xcodebuild \
+            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
+            -scheme "Aidoku (iOS)" \
+            -configuration Release archive \
+            -archivePath build/Aidoku.xcarchive \
+            CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
       - name: Package ipa
         run: |
           mkdir Payload

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,17 +6,27 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Xcode
+      - 
+        uses: actions/checkout@v3
+      - 
+        name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - name: Setup build cache
-        uses: mikehardy/buildcache-action@v1
-      - name: Get commit SHA
+      -
+        name: Caching Xcode derived data
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-${{ hashFiles("**/project.pbxproj") }}-${{ hashFiles("**/*.swift") }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - 
+        name: Get commit SHA
         id: commitinfo
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Build
+      - 
+        name: Build
         run: |
           xcodebuild \
             CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
@@ -24,12 +34,14 @@ jobs:
             -configuration Release archive \
             -archivePath build/Aidoku.xcarchive \
             CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-      - name: Package ipa
+      - 
+        name: Package ipa
         run: |
           mkdir Payload
           cp -r build/Aidoku.xcarchive/Products/Applications/Aidoku.app Payload
           zip -r Aidoku-iOS_nightly-${{ steps.commitinfo.outputs.sha_short }}.ipa Payload
-      - name: Upload artifacts
+      - 
+        name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Aidoku-iOS_nightly-${{ steps.commitinfo.outputs.sha_short }}.ipa

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-${{ hashFiles("**/project.pbxproj") }}-${{ hashFiles("**/*.swift") }}
+          key: ${{ runner.os }}-${{ hashFiles('**/project.pbxproj') }}-${{ hashFiles('**/*.swift') }}
           restore-keys: |
             ${{ runner.os }}-
       - 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,14 +13,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      -
-        name: Caching Xcode derived data
-        uses: actions/cache@v3
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-${{ hashFiles('**/project.pbxproj') }}-${{ hashFiles('**/*.swift') }}
-          restore-keys: |
-            ${{ runner.os }}-
       - 
         name: Get commit SHA
         id: commitinfo
@@ -29,7 +21,6 @@ jobs:
         name: Build
         run: |
           xcodebuild \
-            CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ \
             -scheme "Aidoku (iOS)" \
             -configuration Release archive \
             -archivePath build/Aidoku.xcarchive \

--- a/Shared/Data/Backup/BackupManager.swift
+++ b/Shared/Data/Backup/BackupManager.swift
@@ -23,16 +23,16 @@ class BackupManager {
 
     func save(backup: Backup, url: URL? = nil) {
         Self.directory.createDirectory()
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .secondsSince1970
-        if let json = try? encoder.encode(backup) {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        if let plist = try? encoder.encode(backup) {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
             if let url = url {
-                try? json.write(to: url)
+                try? plist.write(to: url)
             } else {
-                let path = Self.directory.appendingPathComponent("aidoku_\(dateFormatter.string(from: backup.date)).json")
-                try? json.write(to: path)
+                let path = Self.directory.appendingPathComponent("aidoku_\(dateFormatter.string(from: backup.date)).aib")
+                try? plist.write(to: path)
             }
             NotificationCenter.default.post(name: Notification.Name("updateBackupList"), object: nil)
         }

--- a/Shared/Data/Backup/Models/Backup.swift
+++ b/Shared/Data/Backup/Models/Backup.swift
@@ -28,5 +28,7 @@ struct Backup: Codable {
             decoder.dateDecodingStrategy = .secondsSince1970
             return try? decoder.decode(Backup.self, from: data)
         }
+
+        return nil
     }
 }

--- a/Shared/Data/Backup/Models/Backup.swift
+++ b/Shared/Data/Backup/Models/Backup.swift
@@ -21,13 +21,12 @@ struct Backup: Codable {
     static func load(from url: URL) -> Backup? {
         guard let data = try? Data(contentsOf: url) else { return nil }
 
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.dateDecodingStrategy = .secondsSince1970
-
-        if let backup = try? PropertyListDecoder().decode(Backup.self, from: data) {
-            return backup
-        } else {
-            return try? jsonDecoder.decode(Backup.self, from: data)
+        if url.pathExtension == "aib" {
+            return try? PropertyListDecoder().decode(Backup.self, from: data)
+        } else if url.pathExtension == "json" {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .secondsSince1970
+            return try? decoder.decode(Backup.self, from: data)
         }
     }
 }

--- a/Shared/Data/Backup/Models/Backup.swift
+++ b/Shared/Data/Backup/Models/Backup.swift
@@ -19,9 +19,15 @@ struct Backup: Codable {
     var version: String?
 
     static func load(from url: URL) -> Backup? {
-        guard let json = try? Data(contentsOf: url) else { return nil }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-        return try? decoder.decode(Backup.self, from: json)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+
+        if let backup = try? PropertyListDecoder().decode(Backup.self, from: data) {
+            return backup
+        } else {
+            return try? jsonDecoder.decode(Backup.self, from: data)
+        }
     }
 }

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -215,7 +215,6 @@
 "MISSING_SOURCES_TEXT" = "The restored backup may contain data from the following sources, which are not currently installed:";
 "RESTORE_BACKUP" = "Restore to this backup?";
 "RESTORE_BACKUP_TEXT" = "All current data will be removed and replaced by the data from this backup.";
-"RESTORING_BACKUP_ELLIPSIS" = "Restoring backup...";
 "BACKUP_IMPORT_SUCCESS" = "Backup Imported";
 "BACKUP_IMPORT_SUCCESS_TEXT" = "To restore to this backup, find it in the backups page in settings.";
 "BACKUP_IMPORT_FAIL" = "Import Failed";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -215,6 +215,7 @@
 "MISSING_SOURCES_TEXT" = "The restored backup may contain data from the following sources, which are not currently installed:";
 "RESTORE_BACKUP" = "Restore to this backup?";
 "RESTORE_BACKUP_TEXT" = "All current data will be removed and replaced by the data from this backup.";
+"RESTORING_BACKUP_ELLIPSIS" = "Restoring backup...";
 "BACKUP_IMPORT_SUCCESS" = "Backup Imported";
 "BACKUP_IMPORT_SUCCESS_TEXT" = "To restore to this backup, find it in the backups page in settings.";
 "BACKUP_IMPORT_FAIL" = "Import Failed";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -116,7 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Task {
                 _ = await SourceManager.shared.importSource(from: url)
             }
-        } else if url.pathExtension == "json" {
+        } else if url.pathExtension == "json" || url.pathExtension == "aib" {
             if BackupManager.shared.importBackup(from: url) {
                 sendAlert(title: NSLocalizedString("BACKUP_IMPORT_SUCCESS", comment: ""),
                           message: NSLocalizedString("BACKUP_IMPORT_SUCCESS_TEXT", comment: ""))

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -16,6 +16,16 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>
+			<string>Aidoku Backup</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>xyz.skitty.Aidoku.aib</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
 			<string>JSON</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -96,6 +96,25 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.property-list</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Aidoku Backup</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>xyz.skitty.Aidoku.aib</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>aib</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -607,7 +607,7 @@ extension MangaViewController {
     func showMissingSourceWarning(for id: String) {
         let alert = UIAlertController(
             title: NSLocalizedString("MISSING_SOURCE", comment: ""),
-            message: "\(id)\n\(NSLocalizedString("MISSING_SOURCE_TEXT", comment: ""))",
+            message: "\(id)\n\n\(NSLocalizedString("MISSING_SOURCE_TEXT", comment: ""))",
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -127,7 +127,7 @@ class MangaViewController: UIViewController {
 
         source = SourceManager.shared.source(for: manga.sourceId)
         guard let source = source else {
-            showMissingSourceWarning()
+            showMissingSourceWarning(for: manga.sourceId)
             return
         }
 
@@ -604,10 +604,10 @@ extension MangaViewController {
         present(navigationController, animated: true)
     }
 
-    func showMissingSourceWarning() {
+    func showMissingSourceWarning(for id: String) {
         let alert = UIAlertController(
             title: NSLocalizedString("MISSING_SOURCE", comment: ""),
-            message: NSLocalizedString("MISSING_SOURCE_TEXT", comment: ""),
+            message: "\(id)\n\(NSLocalizedString("MISSING_SOURCE_TEXT", comment: ""))",
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -150,7 +150,7 @@ extension BackupsViewController {
                 loadingIndicator.startAnimating();
                 alert.view.addSubview(loadingIndicator)
 
-                present(alert, animated: true)
+                self.present(alert, animated: true)
                 Task {
                     await BackupManager.shared.restore(from: backup)
                     await MainActor.run {

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -139,37 +139,37 @@ extension BackupsViewController {
 
         restoreAlert.addAction(UIAlertAction(title: NSLocalizedString("RESTORE", comment: ""), style: .destructive) { _ in
             if let backup = Backup.load(from: self.backups[indexPath.row]) {
-                let alert = UIAlertController(
-                    title: nil,
-                    message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
-                    preferredStyle: .alert
-                )
-
-                let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
-                loadingIndicator.hidesWhenStopped = true
-                loadingIndicator.style = .medium
-                loadingIndicator.startAnimating();
-                alert.view.addSubview(loadingIndicator)
-
-                self.present(alert, animated: true, completion: nil)
                 Task {
-                    await BackupManager.shared.restore(from: backup)
-                }
-                self.dismiss(animated: true, completion: nil)
-
-                let missingSources = (backup.sources ?? []).filter {
-                    !DataManager.shared.hasSource(id: $0)
-                }
-                if !missingSources.isEmpty {
-                    var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
-                    message += missingSources.map { "\n- \($0)" }.joined()
-                    let missingAlert = UIAlertController(
-                        title: NSLocalizedString("MISSING_SOURCES", comment: ""),
-                        message: message,
+                    let alert = UIAlertController(
+                        title: nil,
+                        message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
                         preferredStyle: .alert
                     )
-                    missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
-                    self.present(missingAlert, animated: true)
+
+                    let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
+                    loadingIndicator.hidesWhenStopped = true
+                    loadingIndicator.style = .medium
+                    loadingIndicator.startAnimating();
+                    alert.view.addSubview(loadingIndicator)
+
+                    self.present(alert, animated: true, completion: nil)
+                    await BackupManager.shared.restore(from: backup)
+                    self.dismiss(animated: true, completion: nil)
+
+                    let missingSources = (backup.sources ?? []).filter {
+                        !DataManager.shared.hasSource(id: $0)
+                    }
+                    if !missingSources.isEmpty {
+                        var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
+                        message += missingSources.map { "\n- \($0)" }.joined()
+                        let missingAlert = UIAlertController(
+                            title: NSLocalizedString("MISSING_SOURCES", comment: ""),
+                            message: message,
+                            preferredStyle: .alert
+                        )
+                        missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
+                        self.present(missingAlert, animated: true)
+                    }
                 }
             }
         })

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -150,11 +150,12 @@ extension BackupsViewController {
                 loadingIndicator.startAnimating()
                 alert.view.addSubview(loadingIndicator)
 
-                self.addSubview(alert)
+                self.present(alert, animated: true)
                 Task { @MainActor in
                     await BackupManager.shared.restore(from: backup)
                     loadingIndicator.stopAnimating()
-                    alert.removeFromSuperview()
+                    loadingIndicator = nil
+                    alert.dismiss(animated: true)                    
 
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -147,13 +147,14 @@ extension BackupsViewController {
                 let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
                 loadingIndicator.hidesWhenStopped = true
                 loadingIndicator.style = .medium
-                loadingIndicator.startAnimating();
+                loadingIndicator.startAnimating()
                 alert.view.addSubview(loadingIndicator)
 
-                self.present(alert, animated: true)
+                self.addSubview(alert)
                 Task { @MainActor in
                     await BackupManager.shared.restore(from: backup)
-                    self.dismiss(animated: false, completion: nil)
+                    loadingIndicator.stopAnimating()
+                    alert.removeFromSuperview()
 
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -139,37 +139,37 @@ extension BackupsViewController {
 
         restoreAlert.addAction(UIAlertAction(title: NSLocalizedString("RESTORE", comment: ""), style: .destructive) { _ in
             if let backup = Backup.load(from: self.backups[indexPath.row]) {
+                let alert = UIAlertController(
+                    title: nil,
+                    message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
+                    preferredStyle: .alert
+                )
+
+                let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
+                loadingIndicator.hidesWhenStopped = true
+                loadingIndicator.style = .medium
+                loadingIndicator.startAnimating();
+                alert.view.addSubview(loadingIndicator)
+
+                self.present(alert, animated: true, completion: nil)
                 Task {
-                    let alert = UIAlertController(
-                        title: nil,
-                        message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
+                    await BackupManager.shared.restore(from: backup)
+                }
+                self.dismiss(animated: true, completion: nil)
+
+                let missingSources = (backup.sources ?? []).filter {
+                    !DataManager.shared.hasSource(id: $0)
+                }
+                if !missingSources.isEmpty {
+                    var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
+                    message += missingSources.map { "\n- \($0)" }.joined()
+                    let missingAlert = UIAlertController(
+                        title: NSLocalizedString("MISSING_SOURCES", comment: ""),
+                        message: message,
                         preferredStyle: .alert
                     )
-
-                    let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
-                    loadingIndicator.hidesWhenStopped = true
-                    loadingIndicator.style = .medium
-                    loadingIndicator.startAnimating();
-                    alert.view.addSubview(loadingIndicator)
-
-                    self.present(alert, animated: true, completion: nil)
-                    await BackupManager.shared.restore(from: backup)
-                    alert.dismiss(animated: false, completion: nil)
-
-                    let missingSources = (backup.sources ?? []).filter {
-                        !DataManager.shared.hasSource(id: $0)
-                    }
-                    if !missingSources.isEmpty {
-                        var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
-                        message += missingSources.map { "\n- \($0)" }.joined()
-                        let missingAlert = UIAlertController(
-                            title: NSLocalizedString("MISSING_SOURCES", comment: ""),
-                            message: message,
-                            preferredStyle: .alert
-                        )
-                        missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
-                        self.present(missingAlert, animated: true)
-                    }
+                    missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
+                    self.present(missingAlert, animated: true)
                 }
             }
         })

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -139,8 +139,23 @@ extension BackupsViewController {
 
         restoreAlert.addAction(UIAlertAction(title: NSLocalizedString("RESTORE", comment: ""), style: .destructive) { _ in
             if let backup = Backup.load(from: self.backups[indexPath.row]) {
+                let alert = UIAlertController(
+                    title: nil,
+                    message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
+                    preferredStyle: .alert
+                )
+                let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
+                loadingIndicator.hidesWhenStopped = true
+                loadingIndicator.style = .medium
+                loadingIndicator.startAnimating();
+                alert.view.addSubview(loadingIndicator)
+
+                present(alert, animated: true)
                 Task {
                     await BackupManager.shared.restore(from: backup)
+                    await MainActor.run {
+                        alert.dismiss(animated: false, completion: nil)
+                    }
 
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -140,7 +140,22 @@ extension BackupsViewController {
         restoreAlert.addAction(UIAlertAction(title: NSLocalizedString("RESTORE", comment: ""), style: .destructive) { _ in
             if let backup = Backup.load(from: self.backups[indexPath.row]) {
                 Task {
+                    let alert = UIAlertController(
+                        title: nil,
+                        message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
+                        preferredStyle: .alert
+                    )
+
+                    let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
+                    loadingIndicator.hidesWhenStopped = true
+                    loadingIndicator.style = UIActivityIndicatorView.Style.gray
+                    loadingIndicator.startAnimating();
+                    alert.view.addSubview(loadingIndicator)
+
+                    present(alert, animated: true, completion: nil)
                     await BackupManager.shared.restore(from: backup)
+                    alert.dismiss(animated: false, completion: nil)
+
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)
                     }

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -151,25 +151,25 @@ extension BackupsViewController {
                 alert.view.addSubview(loadingIndicator)
 
                 self.present(alert, animated: true)
-                Task { @MainActor in
+                Task {
                     await BackupManager.shared.restore(from: backup)
-                    loadingIndicator.stopAnimating()
-                    alert.dismiss(animated: true)                    
+                }
+                loadingIndicator.stopAnimating()
+                alert.dismiss(animated: true)
 
-                    let missingSources = (backup.sources ?? []).filter {
-                        !DataManager.shared.hasSource(id: $0)
-                    }
-                    if !missingSources.isEmpty {
-                        var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
-                        message += missingSources.map { "\n- \($0)" }.joined()
-                        let missingAlert = UIAlertController(
-                            title: NSLocalizedString("MISSING_SOURCES", comment: ""),
-                            message: message,
-                            preferredStyle: .alert
-                        )
-                        missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
-                        self.present(missingAlert, animated: true)
-                    }
+                let missingSources = (backup.sources ?? []).filter {
+                    !DataManager.shared.hasSource(id: $0)
+                }
+                if !missingSources.isEmpty {
+                    var message = NSLocalizedString("MISSING_SOURCES_TEXT", comment: "")
+                    message += missingSources.map { "\n- \($0)" }.joined()
+                    let missingAlert = UIAlertController(
+                        title: NSLocalizedString("MISSING_SOURCES", comment: ""),
+                        message: message,
+                        preferredStyle: .alert
+                    )
+                    missingAlert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
+                    self.present(missingAlert, animated: true)
                 }
             }
         })

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -148,11 +148,11 @@ extension BackupsViewController {
 
                     let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
                     loadingIndicator.hidesWhenStopped = true
-                    loadingIndicator.style = UIActivityIndicatorView.Style.gray
+                    loadingIndicator.style = .medium
                     loadingIndicator.startAnimating();
                     alert.view.addSubview(loadingIndicator)
 
-                    present(alert, animated: true, completion: nil)
+                    self.present(alert, animated: true, completion: nil)
                     await BackupManager.shared.restore(from: backup)
                     alert.dismiss(animated: false, completion: nil)
 

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -154,7 +154,6 @@ extension BackupsViewController {
                 Task { @MainActor in
                     await BackupManager.shared.restore(from: backup)
                     loadingIndicator.stopAnimating()
-                    loadingIndicator = nil
                     alert.dismiss(animated: true)                    
 
                     let missingSources = (backup.sources ?? []).filter {

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -140,21 +140,7 @@ extension BackupsViewController {
         restoreAlert.addAction(UIAlertAction(title: NSLocalizedString("RESTORE", comment: ""), style: .destructive) { _ in
             if let backup = Backup.load(from: self.backups[indexPath.row]) {
                 Task {
-                    let alert = UIAlertController(
-                        title: nil,
-                        message: NSLocalizedString("RESTORING_BACKUP_ELLIPSIS", comment: ""),
-                        preferredStyle: .alert
-                    )
-
-                    let loadingIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 5, width: 50, height: 50))
-                    loadingIndicator.hidesWhenStopped = true
-                    loadingIndicator.style = .medium
-                    loadingIndicator.startAnimating();
-                    alert.view.addSubview(loadingIndicator)
-
-                    self.present(alert, animated: true, completion: nil)
                     await BackupManager.shared.restore(from: backup)
-                    self.dismiss(animated: true, completion: nil)
 
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)

--- a/iOS/UI/Settings/BackupsViewController.swift
+++ b/iOS/UI/Settings/BackupsViewController.swift
@@ -151,11 +151,9 @@ extension BackupsViewController {
                 alert.view.addSubview(loadingIndicator)
 
                 self.present(alert, animated: true)
-                Task {
+                Task { @MainActor in
                     await BackupManager.shared.restore(from: backup)
-                    await MainActor.run {
-                        alert.dismiss(animated: false, completion: nil)
-                    }
+                    self.dismiss(animated: false, completion: nil)
 
                     let missingSources = (backup.sources ?? []).filter {
                         !DataManager.shared.hasSource(id: $0)


### PR DESCRIPTION
### Description
* Create new backups with the binary plist format (old JSON backups are still importable) to save about 15% storage.
* Specify which source is missing when displaying the "Missing Source" alert.

### Todo
* Compress backups.
* Add a loading indicator when restoring backups.