### PR TITLE
Migrate to Nuke 12

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -2137,7 +2137,7 @@
 			repositoryURL = "https://github.com/kean/Nuke";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.0.0;
+				minimumVersion = 12.0.0;
 			};
 		};
 		FB31AD0D27AE18DA00D50410 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/Aidoku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Aidoku.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "3ed0597082b40932481fb8971af8813a4284203c",
-        "version" : "11.6.1"
+        "revision" : "3f666f120b63ea7de57d42e9a7c9b47f8e7a290b",
+        "version" : "12.1.6"
       }
     },
     {

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -112,6 +112,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DataLoader.sharedUrlCache.diskCapacity = 0
 
         let pipeline = ImagePipeline {
+            let dataLoader: DataLoader = {
+                let config = URLSessionConfiguration.default
+                config.urlCache = nil
+                return DataLoader(configuration: config)
+            }()
             let dataCache = try? DataCache(name: "xyz.skitty.Aidoku.datacache") // disk cache
             let imageCache = Nuke.ImageCache() // memory cache
             dataCache?.sizeLimit = 500 * 1024 * 1024
@@ -119,6 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             imageCache.countLimit = 150
             $0.dataCache = dataCache
             $0.imageCache = imageCache
+            $0.dataLoader = dataLoader
         }
 
         ImagePipeline.shared = pipeline

--- a/iOS/Old UI/Base/Manga/MangaCoverCell.swift
+++ b/iOS/Old UI/Base/Manga/MangaCoverCell.swift
@@ -240,21 +240,18 @@ class MangaCoverCell: UICollectionViewCell {
             processors: [DownsampleProcessor(width: bounds.width)]
         )
 
-        imageTask = ImagePipeline.shared.loadImage(
-            with: request,
-            completion: { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let response):
-                    Task { @MainActor in
-                        UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
-                            self.imageView.image = response.image
-                        }
+        imageTask = ImagePipeline.shared.loadImage(with: request) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let response):
+                Task { @MainActor in
+                    UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
+                        self.imageView.image = response.image
                     }
-                case .failure:
-                    imageTask = nil
                 }
+            case .failure:
+                imageTask = nil
             }
-        )
+        }
     }
 }

--- a/iOS/Old UI/Base/Manga/MangaCoverCell.swift
+++ b/iOS/Old UI/Base/Manga/MangaCoverCell.swift
@@ -241,7 +241,7 @@ class MangaCoverCell: UICollectionViewCell {
         )
 
         imageTask = ImagePipeline.shared.loadImage(with: request) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let response):
                 Task { @MainActor in

--- a/iOS/Old UI/Base/Manga/MangaCoverCell.swift
+++ b/iOS/Old UI/Base/Manga/MangaCoverCell.swift
@@ -240,23 +240,21 @@ class MangaCoverCell: UICollectionViewCell {
             processors: [DownsampleProcessor(width: bounds.width)]
         )
 
-        do {
-            let image = try await ImagePipeline.shared.image(for: request, delegate: self).image
-            Task { @MainActor in
-                UIView.transition(with: imageView, duration: 0.3, options: .transitionCrossDissolve) {
-                    self.imageView.image = image
+        imageTask = ImagePipeline.shared.loadImage(
+            with: request,
+            completion: { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let response):
+                    Task { @MainActor in
+                        UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
+                            self.imageView.image = response.image
+                        }
+                    }
+                case .failure:
+                    imageTask = nil
                 }
             }
-        } catch {
-            imageTask = nil
-        }
-    }
-}
-
-// MARK: - Nuke Delegate
-extension MangaCoverCell: ImageTaskDelegate {
-
-    func imageTaskCreated(_ task: ImageTask) {
-        imageTask = task
+        )
     }
 }

--- a/iOS/Old UI/History/HistoryTableViewCell.swift
+++ b/iOS/Old UI/History/HistoryTableViewCell.swift
@@ -116,7 +116,7 @@ class HistoryTableViewCell: UITableViewCell {
         else { return }
 
         let request = ImageRequest(url: url, processors: [DownsampleProcessor(size: bounds.size)])
-        if let image = try? await ImagePipeline.shared.image(for: request).image {
+        if let image = try? await ImagePipeline.shared.image(for: request) {
             Task { @MainActor in
                 UIView.transition(with: imageView, duration: 0.3, options: .transitionCrossDissolve) {
                     imageView.image = image

--- a/iOS/Old UI/Manga/Tracking/TrackerSearchTableViewCell.swift
+++ b/iOS/Old UI/Manga/Tracking/TrackerSearchTableViewCell.swift
@@ -130,7 +130,7 @@ class TrackerSearchTableViewCell: UITableViewCell {
         else { return }
 
         let request = ImageRequest(url: url, processors: [DownsampleProcessor(size: bounds.size)])
-        if let image = try? await ImagePipeline.shared.image(for: request).image {
+        if let image = try? await ImagePipeline.shared.image(for: request) {
             Task { @MainActor in
                 UIView.transition(with: imageView, duration: 0.3, options: .transitionCrossDissolve) {
                     imageView.image = image

--- a/iOS/UI/Browse/SourceTableViewCell.swift
+++ b/iOS/UI/Browse/SourceTableViewCell.swift
@@ -179,26 +179,23 @@ class SourceTableViewCell: UITableViewCell {
         )
         let wasCached = ImagePipeline.shared.cache.containsCachedImage(for: request)
 
-        imageTask = ImagePipeline.shared.loadImage(
-            with: request,
-            completion: { [weak self] result in
-                guard let self = self else { return }
-                switch result {
-                case .success(let response):
-                    Task { @MainActor in
-                        if wasCached {
+        imageTask = ImagePipeline.shared.loadImage(with: request) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let response):
+                Task { @MainActor in
+                    if wasCached {
+                        self.iconView.image = response.image
+                    } else {
+                        UIView.transition(with: self.iconView, duration: 0.3, options: .transitionCrossDissolve) {
                             self.iconView.image = response.image
-                        } else {
-                            UIView.transition(with: self.iconView, duration: 0.3, options: .transitionCrossDissolve) {
-                                self.iconView.image = response.image
-                            }
                         }
                     }
-                case .failure:
-                    imageTask = nil
                 }
+            case .failure:
+                imageTask = nil
             }
-        )
+        }
     }
 
     @objc func getPressed() {

--- a/iOS/UI/Browse/SourceTableViewCell.swift
+++ b/iOS/UI/Browse/SourceTableViewCell.swift
@@ -177,21 +177,28 @@ class SourceTableViewCell: UITableViewCell {
             url: url,
             processors: [DownsampleProcessor(width: bounds.width)]
         )
-        do {
-            let wasCached = ImagePipeline.shared.cache.containsCachedImage(for: request)
-            let image = try await ImagePipeline.shared.image(for: request, delegate: self).image
-            Task { @MainActor in
-                if wasCached {
-                    self.iconView.image = image
-                } else {
-                    UIView.transition(with: iconView, duration: 0.3, options: .transitionCrossDissolve) {
-                        self.iconView.image = image
+        let wasCached = ImagePipeline.shared.cache.containsCachedImage(for: request)
+
+        imageTask = ImagePipeline.shared.loadImage(
+            with: request,
+            completion: { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let response):
+                    Task { @MainActor in
+                        if wasCached {
+                            self.iconView.image = response.image
+                        } else {
+                            UIView.transition(with: self.iconView, duration: 0.3, options: .transitionCrossDissolve) {
+                                self.iconView.image = response.image
+                            }
+                        }
                     }
+                case .failure:
+                    imageTask = nil
                 }
             }
-        } catch {
-            imageTask = nil
-        }
+        )
     }
 
     @objc func getPressed() {
@@ -208,13 +215,5 @@ class SourceTableViewCell: UITableViewCell {
             )
             getButton.buttonState = installedSource == nil ? .fail : .get
         }
-    }
-}
-
-// MARK: - Nuke Delegate
-extension SourceTableViewCell: ImageTaskDelegate {
-
-    func imageTaskCreated(_ task: ImageTask) {
-        imageTask = task
     }
 }

--- a/iOS/UI/Common/Manga/MangaGridCell.swift
+++ b/iOS/UI/Common/Manga/MangaGridCell.swift
@@ -268,25 +268,22 @@ class MangaGridCell: UICollectionViewCell {
         if let image = ImagePipeline.shared.cache.cachedImage(for: request) {
             imageView.image = image.image
         } else {
-            imageTask = ImagePipeline.shared.loadImage(
-                with: request,
-                completion: { [weak self] result in
-                    guard let self = self else { return }
-                    switch result {
-                    case .success(let response):
-                        if response.request.imageId != self.url {
-                            return
-                        }
-                        Task { @MainActor in
-                            UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
-                                self.imageView.image = response.image
-                            }
-                        }
-                    case .failure:
-                        imageTask = nil
+            imageTask = ImagePipeline.shared.loadImage(with: request) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .success(let response):
+                    if response.request.imageId != self.url {
+                        return
                     }
+                    Task { @MainActor in
+                        UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
+                            self.imageView.image = response.image
+                        }
+                    }
+                case .failure:
+                    imageTask = nil
                 }
-            )
+            }
         }
     }
 

--- a/iOS/UI/Common/Manga/MangaGridCell.swift
+++ b/iOS/UI/Common/Manga/MangaGridCell.swift
@@ -268,11 +268,25 @@ class MangaGridCell: UICollectionViewCell {
         if let image = ImagePipeline.shared.cache.cachedImage(for: request) {
             imageView.image = image.image
         } else {
-            do {
-                _ = try await ImagePipeline.shared.image(for: request, delegate: self).image
-            } catch {
-                imageTask = nil
-            }
+            imageTask = ImagePipeline.shared.loadImage(
+                with: request,
+                completion: { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success(let response):
+                        if response.request.imageId != self.url {
+                            return
+                        }
+                        Task { @MainActor in
+                            UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
+                                self.imageView.image = response.image
+                            }
+                        }
+                    case .failure:
+                        imageTask = nil
+                    }
+                }
+            )
         }
     }
 
@@ -312,38 +326,6 @@ class MangaGridCell: UICollectionViewCell {
         UIView.animate(withDuration: animated ? 0.3 : 0) {
             self.shadowOverlayView.alpha = 1
             self.selectionView.layer.shadowOpacity = 0
-        }
-    }
-}
-
-// MARK: - Nuke Delegate
-extension MangaGridCell: ImageTaskDelegate {
-
-    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
-        switch result {
-        case .success(let response):
-            if task.request.imageId != url {
-                return
-            }
-            Task { @MainActor in
-                UIView.transition(with: imageView, duration: 0.3, options: .transitionCrossDissolve) {
-                    self.imageView.image = response.image
-                }
-            }
-        case .failure:
-            break
-        }
-    }
-
-    func imageTaskCreated(_ task: ImageTask) {
-        Task { @MainActor in
-            imageTask = task
-        }
-    }
-
-    func imageTaskDidCancel(_ task: ImageTask) {
-        Task { @MainActor in
-            imageTask = nil
         }
     }
 }

--- a/iOS/UI/Manga/MangaCoverViewController.swift
+++ b/iOS/UI/Manga/MangaCoverViewController.swift
@@ -105,7 +105,7 @@ class MangaCoverViewController: BaseViewController {
 
         let request = ImageRequest(urlRequest: URLRequest(url: coverUrl))
 
-        guard let image = try? await ImagePipeline.shared.image(for: request).image else { return }
+        guard let image = try? await ImagePipeline.shared.image(for: request) else { return }
         Task { @MainActor in
             UIView.transition(with: coverImageView, duration: 0.3, options: .transitionCrossDissolve) {
                 self.coverImageView.image = image

--- a/iOS/UI/Manga/MangaDetailHeaderView.swift
+++ b/iOS/UI/Manga/MangaDetailHeaderView.swift
@@ -417,7 +417,7 @@ class MangaDetailHeaderView: UIView {
             processors: [DownsampleProcessor(width: bounds.width)]
         )
 
-        guard let image = try? await ImagePipeline.shared.image(for: request).image else { return }
+        guard let image = try? await ImagePipeline.shared.image(for: request) else { return }
         Task { @MainActor in
             UIView.transition(with: coverImageView, duration: 0.3, options: .transitionCrossDissolve) {
                 self.coverImageView.image = image

--- a/iOS/UI/Migration/MangaGridView.swift
+++ b/iOS/UI/Migration/MangaGridView.swift
@@ -19,6 +19,8 @@ struct MangaGridView: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+            } else {
+                Image("MangaPlaceholder")
             }
         }
         .cornerRadius(5)

--- a/iOS/UI/Migration/MangaGridView.swift
+++ b/iOS/UI/Migration/MangaGridView.swift
@@ -14,29 +14,35 @@ struct MangaGridView: View {
     var coverUrl: URL?
 
     var body: some View {
-        LazyImage(url: coverUrl, resizingMode: .aspectFill)
+        LazyImage(url: coverUrl) { state in
+            if let image = state.image {
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            }
+        }
+        .cornerRadius(5)
+        .foregroundColor(Color(UIColor.red))
+        .overlay(
+            LinearGradient(gradient: Gradient(colors: [
+                Color.black.opacity(0.01),
+                Color.black.opacity(0.7)
+            ]), startPoint: .top, endPoint: .bottom)
             .cornerRadius(5)
-            .foregroundColor(Color(UIColor.red))
-            .overlay(
-                LinearGradient(gradient: Gradient(colors: [
-                    Color.black.opacity(0.01),
-                    Color.black.opacity(0.7)
-                ]), startPoint: .top, endPoint: .bottom)
-                .cornerRadius(5)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 5)
-                    .stroke(Color(UIColor.quaternarySystemFill), lineWidth: 1)
-            )
-            .overlay(
-                Text(title ?? "")
-                    .foregroundColor(.white)
-                    .font(.system(size: 15, weight: .medium))
-                    .multilineTextAlignment(.leading)
-                    .lineLimit(2)
-                    .padding(8),
-                alignment: .bottomLeading
-            )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(Color(UIColor.quaternarySystemFill), lineWidth: 1)
+        )
+        .overlay(
+            Text(title ?? "")
+                .foregroundColor(.white)
+                .font(.system(size: 15, weight: .medium))
+                .multilineTextAlignment(.leading)
+                .lineLimit(2)
+                .padding(8),
+            alignment: .bottomLeading
+        )
     }
 }
 

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -139,11 +139,11 @@ class ReaderPageView: UIView {
         imageTask = ImagePipeline.shared.loadImage(
             with: request,
             progress: { [weak self] _, completed, total in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.progressView.setProgress(value: Float(completed) / Float(total), withAnimation: false)
             },
             completion: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let response):
                     imageView.image = response.image

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -136,16 +136,27 @@ class ReaderPageView: UIView {
             )
         }
 
-        let success: Bool
+        imageTask = ImagePipeline.shared.loadImage(
+            with: request,
+            progress: { [weak self] _, completed, total in
+                guard let self = self else { return }
+                self.progressView.setProgress(value: Float(completed) / Float(total), withAnimation: false)
+            },
+            completion: { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success(let response):
+                    imageView.image = response.image
+                    fixImageSize()
+                    completion?(true)
+                case .failure:
+                    completion?(false)
+                }
+                progressView.isHidden = true
+            }
+        )
 
-        do {
-            _ = try await ImagePipeline.shared.image(for: request, delegate: self).image
-            success = true
-        } catch {
-            success = false
-        }
-
-        return success
+        return true
     }
 
     func setPageImage(base64: String, key: Int) async -> Bool {
@@ -222,35 +233,5 @@ class ReaderPageView: UIView {
         }
         imageWidthConstraint?.isActive = true
         imageHeightConstraint?.isActive = true
-    }
-}
-
-// MARK: - Nuke Delegate
-extension ReaderPageView: ImageTaskDelegate {
-
-    func imageTaskCreated(_ task: ImageTask) {
-        Task { @MainActor in
-            imageTask = task
-        }
-    }
-
-    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
-        switch result {
-        case .success(let response):
-            imageView.image = response.image
-            fixImageSize()
-            completion?(true)
-        case .failure:
-            completion?(false)
-        }
-        progressView.isHidden = true
-    }
-
-    func imageTaskDidCancel(_ task: ImageTask) {
-        completion?(false)
-    }
-
-    func imageTask(_ task: ImageTask, didUpdateProgress progress: ImageTask.Progress) {
-        progressView.setProgress(value: Float(progress.completed) / Float(progress.total), withAnimation: false)
     }
 }

--- a/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonImageNode.swift
+++ b/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonImageNode.swift
@@ -227,13 +227,13 @@ extension ReaderWebtoonImageNode {
         _ = ImagePipeline.shared.loadImage(
             with: request,
             progress: { [weak self] _, completed, total in
-                guard let self = self else { return }
+                guard let self else { return }
                 Task { @MainActor in
                     self.progressView.setProgress(value: Float(completed) / Float(total), withAnimation: false)
                 }
             },
             completion: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 loading = false
                 switch result {
                 case .success(let response):

--- a/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonImageNode.swift
+++ b/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonImageNode.swift
@@ -21,7 +21,6 @@ class ReaderWebtoonImageNode: BaseObservingCellNode {
         }
     }
     var ratio: CGFloat?
-    private var imageTask: ImageTask?
     private var loading = false
 
     var pillarbox = UserDefaults.standard.bool(forKey: "Reader.pillarbox")
@@ -225,7 +224,31 @@ extension ReaderWebtoonImageNode {
             processors: processors
         )
 
-        _ = try? await ImagePipeline.shared.image(for: request, delegate: self)
+        _ = ImagePipeline.shared.loadImage(
+            with: request,
+            progress: { [weak self] _, completed, total in
+                guard let self = self else { return }
+                Task { @MainActor in
+                    self.progressView.setProgress(value: Float(completed) / Float(total), withAnimation: false)
+                }
+            },
+            completion: { [weak self] result in
+                guard let self = self else { return }
+                loading = false
+                switch result {
+                case .success(let response):
+                    image = response.image
+                    if isNodeLoaded {
+                        displayImage()
+                    }
+                case .failure:
+                    // TODO: handle failure
+                    Task { @MainActor in
+                        self.progressView.setProgress(value: 0, withAnimation: true)
+                    }
+                }
+            }
+        )
     }
 
     private func loadImage(base64: String) {
@@ -292,35 +315,5 @@ extension ReaderWebtoonImageNode {
         let size = CGSize(width: UIScreen.main.bounds.width, height: scaledHeight)
         frame = CGRect(origin: .zero, size: size)
         transitionLayout(with: ASSizeRange(min: .zero, max: size), animated: true, shouldMeasureAsync: false)
-    }
-}
-
-// MARK: - Nuke Delegate
-extension ReaderWebtoonImageNode: ImageTaskDelegate {
-
-    func imageTaskCreated(_ task: ImageTask) {
-        imageTask = task
-    }
-
-    func imageTask(_ task: ImageTask, didCompleteWithResult result: Result<ImageResponse, ImagePipeline.Error>) {
-        loading = false
-        switch result {
-        case .success(let response):
-            image = response.image
-            if isNodeLoaded {
-                displayImage()
-            }
-        case .failure:
-            // TODO: handle failure
-            progressView.setProgress(value: 0, withAnimation: true)
-        }
-    }
-
-    func imageTaskDidCancel(_ task: ImageTask) {
-        // TODO: handle failure
-    }
-
-    func imageTask(_ task: ImageTask, didUpdateProgress progress: ImageTask.Progress) {
-        progressView.setProgress(value: Float(progress.completed) / Float(progress.total), withAnimation: false)
     }
 }


### PR DESCRIPTION
- The `ImageTaskDelegate` was removed so I had to modify how the image tasks where loaded
- ~~I'm not really sure about the changes on `ReaderPageView`~~
- I added a custom `DataLoader` to the shared `ImagePipeline` as it's recommended in the [docs](https://kean-docs.github.io/nuke/documentation/nuke/cache-layers#Aggressive-Disk-Cache) if using a custom `DataCache`