### PR TITLE
Crop borders: more memory fixes

### DIFF
--- a/iOS/UI/Reader/Page/CropBordersProcessor.swift
+++ b/iOS/UI/Reader/Page/CropBordersProcessor.swift
@@ -34,23 +34,14 @@ struct CropBordersProcessor: ImageProcessing {
         let heightFloat = CGFloat(height)
         let widthFloat = CGFloat(width)
 
-        let bitmapBytesPerRow = width * 4
-        let bitmapByteCount = bitmapBytesPerRow * height
-        let bitmapData = UnsafeMutablePointer<UInt8>.allocate(capacity: bitmapByteCount)
-        defer {
-            bitmapData.deallocate()
-        }
-
-        guard let context = createARGBBitmapContext(data: bitmapData, width: width, height: height) else {
+        guard
+            let context = createARGBBitmapContext(width: width, height: height),
+            let data = context.data?.assumingMemoryBound(to: UInt8.self)
+        else {
             return CGRect.zero
         }
 
-        let rect = CGRect(x: 0, y: 0, width: width, height: height)
-        context.draw(cgImage, in: rect)
-
-        guard let data = context.data?.assumingMemoryBound(to: UInt8.self) else {
-            return CGRect.zero
-        }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
 
         var lowX = widthFloat
         var lowY = heightFloat
@@ -97,14 +88,14 @@ struct CropBordersProcessor: ImageProcessing {
         return CGRect(x: lowX, y: lowY, width: highX - lowX, height: highY - lowY)
     }
 
-    func createARGBBitmapContext(data: UnsafeMutableRawPointer, width: Int, height: Int) -> CGContext? {
+    func createARGBBitmapContext(width: Int, height: Int) -> CGContext? {
 
         let bitmapBytesPerRow = width * 4
 
         let colorSpace = CGColorSpaceCreateDeviceRGB()
 
         let context = CGContext(
-            data: data,
+            data: nil,
             width: width,
             height: height,
             bitsPerComponent: 8,


### PR DESCRIPTION
Two things done here:
- Pass nil to `CGContext` `data` so we don't need to worry about managing its memory
- Use `UIGraphicsImageRenderer` to crop the `CGImage`. For some reason the `cropping` call wasn't releasing the original image reference in the nuke processor but doing it inside the renderer frees the memory used.