### PR TITLE
Copy manga title from manga details

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -19,6 +19,7 @@
 "CLEAR" = "Clear";
 "LOADING_ELLIPSIS" = "Loading…";
 "SHARE" = "Share";
+"COPY" = "Copy";
 
 // Downloads
 "DOWNLOAD" = "Download";

--- a/Shared/Localization/pt-BR.lproj/Localizable.strings
+++ b/Shared/Localization/pt-BR.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "RESET" = "Redefinir";
 "DELETE" = "Excluir";
 "RENAME" = "Renomear";
+"COPY" = "Copiar";
 
 // Library
 "LIBRARY" = "Biblioteca";

--- a/iOS/UI/Manga/MangaDetailHeaderView.swift
+++ b/iOS/UI/Manga/MangaDetailHeaderView.swift
@@ -80,8 +80,13 @@ class MangaDetailHeaderView: UIView {
     // title label
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
+
+        let titleLongPress = UILongPressGestureRecognizer(target: self, action: #selector(titlePressed))
+        titleLabel.addGestureRecognizer(titleLongPress)
+
         titleLabel.numberOfLines = 3
         titleLabel.font = .systemFont(ofSize: 22, weight: .semibold)
+        titleLabel.isUserInteractionEnabled = true
         return titleLabel
     }()
 
@@ -554,6 +559,20 @@ class MangaDetailHeaderView: UIView {
     }
     @objc private func bookmarkHoldCancelled() {
         NSObject.cancelPreviousPerformRequests(withTarget: self)
+    }
+
+    @objc private func titlePressed(_ recognizer: UIGestureRecognizer) {
+        guard
+            recognizer.state == .began,
+            let recognizerView = recognizer.view
+        else { return }
+        let menuController = UIMenuController.shared
+        menuController.menuItems = [UIMenuItem(title: NSLocalizedString("COPY", comment: ""), action: #selector(copyTitleText))]
+        menuController.showMenu(from: recognizerView, rect: recognizerView.frame)
+    }
+    
+    @objc private func copyTitleText() {
+        UIPasteboard.general.string = titleLabel.text
     }
 }
 

--- a/iOS/UI/Manga/MangaDetailHeaderView.swift
+++ b/iOS/UI/Manga/MangaDetailHeaderView.swift
@@ -570,7 +570,7 @@ class MangaDetailHeaderView: UIView {
         menuController.menuItems = [UIMenuItem(title: NSLocalizedString("COPY", comment: ""), action: #selector(copyTitleText))]
         menuController.showMenu(from: recognizerView, rect: recognizerView.frame)
     }
-    
+
     @objc private func copyTitleText() {
         UIPasteboard.general.string = titleLabel.text
     }


### PR DESCRIPTION
Allow to copy manga title when long pressing the title in the manga details.

I added translation to my language only. It's probably just a matter of using a translator for the others since it's a basic vocabulary word. I can do that if it's not a problem.