### PR TITLE
Improve memory usage when using processors

### DIFF
--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -126,6 +126,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             $0.imageCache = imageCache
             $0.dataLoader = dataLoader
             $0.dataCachePolicy = .automatic
+            $0.isStoringPreviewsInMemoryCache = false
         }
 
         ImagePipeline.shared = pipeline

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -125,6 +125,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             $0.dataCache = dataCache
             $0.imageCache = imageCache
             $0.dataLoader = dataLoader
+            $0.dataCachePolicy = .automatic
         }
 
         ImagePipeline.shared = pipeline

--- a/iOS/UI/Reader/Page/CropBordersProcessor.swift
+++ b/iOS/UI/Reader/Page/CropBordersProcessor.swift
@@ -29,16 +29,10 @@ struct CropBordersProcessor: ImageProcessing {
             let newRect = createCropRect(downsampledCGImage)
             guard !newRect.isEmpty else { return image }
 
-            let renderer = UIGraphicsImageRenderer(size: newRect.size)
-            return renderer.image { context in
-                // UIImage and CGContext coordinates are flipped.
-                var transform = CGAffineTransform(scaleX: 1, y: -1)
-                transform = transform.translatedBy(x: 0, y: -newRect.height)
-                context.cgContext.concatenate(transform)
-
-                if let croppedImage = cgImage.cropping(to: newRect) {
-                    context.cgContext.draw(croppedImage, in: CGRect(origin: .zero, size: newRect.size))
-                }
+            if let croppedImage = cgImage.cropping(to: newRect) {
+                return PlatformImage(cgImage: croppedImage)
+            } else {
+                return image
             }
         }
     }


### PR DESCRIPTION
- Changed Nuke `dataCachePolicy` to `automatic`. So processed images are saved in memory cache, instead of the unprocessed ones.
- Disabled the `isStoringPreviewsInMemoryCache` Nuke option. This reduces the memory usage and in my tests it doesn't seem to affect anything.
- Removed the `UIGraphicsImageRenderer` in `CropBorderProcessor`. In my experience this doesn't fix anything, it just makes Xcode report the memory used to "Other Processes".