### PR TITLE
Fix double url string encoding in ios17

### DIFF
--- a/Shared/Wasm/Imports/WasmNet.swift
+++ b/Shared/Wasm/Imports/WasmNet.swift
@@ -243,10 +243,9 @@ extension WasmNet {
             // iOS 17 encodes by default the url string causing double encoded characters
             if #available(iOS 17.0, *) {
                 // it seems if we pass a valid RFC 3986 url string to URL() it behaves the same as on iOS 16
-                // so we need to manually encode strange characters like [] or <>
                 let urlEncoded = request.URL?
-                    .replacingOccurrences(of: "[", with: "%5B")
-                    .replacingOccurrences(of: "]", with: "%5D")
+                    .removingPercentEncoding?
+                    .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
                 url = URL(string: urlEncoded ?? "", encodingInvalidCharacters: false)
             } else {
                 url = URL(string: request.URL ?? "")

--- a/Shared/Wasm/Imports/WasmNet.swift
+++ b/Shared/Wasm/Imports/WasmNet.swift
@@ -239,7 +239,7 @@ extension WasmNet {
     var send: (Int32) -> Void {
         { descriptor in
             guard let request = self.globalStore.requests[descriptor] else { return }
-            var url: URL?
+            let url: URL?
             // iOS 17 encodes by default the url string causing double encoded characters
             if #available(iOS 17.0, *) {
                 // it seems if we pass a valid RFC 3986 url string to URL() it behaves the same as on iOS 16


### PR DESCRIPTION
- Fixes mangadex search query and possibly other sources

It works but I'm still not sure, let me know if something can be improved.