### PR TITLE
Reverse download order for all or unread chapters

### DIFF
--- a/Shared/Data/Downloads/DownloadManager.swift
+++ b/Shared/Data/Downloads/DownloadManager.swift
@@ -93,7 +93,7 @@ extension DownloadManager {
 
     func downloadAll(manga: Manga) async {
         let chapters = await CoreDataManager.shared.getChapters(sourceId: manga.sourceId, mangaId: manga.id)
-        download(chapters: chapters, manga: manga)
+        download(chapters: chapters.reversed(), manga: manga)
     }
 
     func downloadUnread(manga: Manga) async {
@@ -101,7 +101,7 @@ extension DownloadManager {
         let chapters = await CoreDataManager.shared.getChapters(sourceId: manga.sourceId, mangaId: manga.id).filter {
             readingHistory[$0.id] == nil || readingHistory[$0.id]?.page != -1
         }
-        download(chapters: chapters, manga: manga)
+        download(chapters: chapters.reversed(), manga: manga)
     }
 
     func download(chapters: [Chapter], manga: Manga? = nil) {


### PR DESCRIPTION
### Background

Currently when downloading all chapters or unread chapters the download order is set from last to first.
This PR should reverse the order and instead download from first to last.
Having the order from first to last will allow users to start reading as soon as the first chapter is loaded.

### What has been done

1. Reversed order of chapters for `downloadAll` function
2. Reversed order of chapters for `downloadUnread` function

### How to test

1. Have at least a manga in the library
2. Long press the title from the library
3. From the menu select "Download" -> "All"
4. In the download Que observe that the download order is from first to last
5. Clear the queue
6. Mark a few chapters as read
7. Back from the library on long press select "Download" -> "Unread"
8. Make sure the order is from first unread to last

### Checklist

- [x] I didn't add new warnings
- [x] I didn't break localisations
- [x] I didn't break UI 