### PR TITLE
Use "ellipsis.circle" for 3-dot menu

### DIFF
--- a/iOS/Old UI/Manga/Tracking/TrackerView.swift
+++ b/iOS/Old UI/Manga/Tracking/TrackerView.swift
@@ -77,7 +77,7 @@ struct TrackerView: View {
                         )
                     }
                 } label: {
-                    Image(systemName: "ellipsis")
+                    Image(systemName: "ellipsis.circle")
                         .padding([.vertical, .leading]) // increase hitbox
                 }
             }

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -37,7 +37,7 @@ class LibraryViewController: MangaCollectionViewController {
     )
 
     private lazy var moreBarButton = UIBarButtonItem(
-        image: UIImage(systemName: "ellipsis"),
+        image: UIImage(systemName: "ellipsis.circle"),
         style: .plain,
         target: nil,
         action: nil

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -739,7 +739,7 @@ extension MangaViewController {
             }
 
             let moreButton = UIBarButtonItem(
-                image: UIImage(systemName: "ellipsis"),
+                image: UIImage(systemName: "ellipsis.circle"),
                 style: .plain,
                 target: self,
                 action: nil

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -84,7 +84,7 @@ class ReaderViewController: BaseObservingViewController {
         ]
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(
-                image: UIImage(systemName: "ellipsis"),
+                image: UIImage(systemName: "ellipsis.circle"),
                 style: .plain,
                 target: nil,
                 action: nil

--- a/iOS/UI/Source/SourceViewController.swift
+++ b/iOS/UI/Source/SourceViewController.swift
@@ -201,7 +201,7 @@ class SourceViewController: MangaCollectionViewController {
     func updateNavbarItems(showFilterButton: Bool = true, listingsHidden: Bool = false) {
         var items = [
             UIBarButtonItem(
-                image: UIImage(systemName: "ellipsis"),
+                image: UIImage(systemName: "ellipsis.circle"),
                 style: .plain,
                 target: self,
                 action: #selector(openInfoPage)


### PR DESCRIPTION
Most of Apple apps uses `ellipsis.circle` for the 3-dot icon menu. I personally think that it looks better:

<img height="600" src="https://github.com/Aidoku/Aidoku/assets/12379835/5dcb99bf-d5f6-4ed4-8890-85c8a5ba8735" />
