### PR TITLE
feat: adds page background color option

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -263,6 +263,10 @@
 "PAGED" = "Paged";
 "PAGE_LAYOUT" = "Page Layout";
 "DOUBLE_PAGE" = "Double Page";
+"PAGE_BG_COLOR" = "Page Background Color";
+"PAGE_BG_COLOR_SYSTEM" = "System";
+"PAGE_BG_COLOR_LIGHT" = "Light";
+"PAGE_BG_COLOR_DARK" = "Dark";
 "MULTI_LANGUAGE" = "Multi-Language";
 "TRACKERS" = "Trackers";
 "LOGOUT" = "Log out";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -212,6 +212,10 @@
 "DOWNSAMPLE_IMAGES" = "Downsample Images";
 "CROP_BORDERS" = "Crop Borders";
 "SAVE_IMAGE_OPTION" = "Save Image Option";
+"READER_BG_COLOR" = "Background Color";
+"READER_BG_COLOR_SYSTEM" = "System";
+"READER_BG_COLOR_WHITE" = "White";
+"READER_BG_COLOR_BLACK" = "Black";
 "BACKUPS" = "Backups";
 "BACKUP_NAME" = "Backup Name";
 "RENAME_BACKUP" = "Rename Backup";
@@ -263,10 +267,6 @@
 "PAGED" = "Paged";
 "PAGE_LAYOUT" = "Page Layout";
 "DOUBLE_PAGE" = "Double Page";
-"PAGE_BG_COLOR" = "Page Background Color";
-"PAGE_BG_COLOR_SYSTEM" = "System";
-"PAGE_BG_COLOR_LIGHT" = "Light";
-"PAGE_BG_COLOR_DARK" = "Dark";
 "MULTI_LANGUAGE" = "Multi-Language";
 "TRACKERS" = "Trackers";
 "LOGOUT" = "Log out";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -111,6 +111,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Reader.downsampleImages": true,
                 "Reader.cropBorders": false,
                 "Reader.saveImageOption": true,
+                "Reader.pageBackgroundColor": "dark",
                 "Reader.pagesToPreload": 2,
                 "Reader.pagedPageLayout": "auto",
                 "Reader.verticalInfiniteScroll": true,

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -111,7 +111,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Reader.downsampleImages": true,
                 "Reader.cropBorders": false,
                 "Reader.saveImageOption": true,
-                "Reader.pageBackgroundColor": "dark",
+                "Reader.backgroundColor": "black",
                 "Reader.pagesToPreload": 2,
                 "Reader.pagedPageLayout": "auto",
                 "Reader.verticalInfiniteScroll": true,

--- a/iOS/Old UI/Reader/ReaderSettingsViewController.swift
+++ b/iOS/Old UI/Reader/ReaderSettingsViewController.swift
@@ -33,7 +33,18 @@ class ReaderSettingsViewController: SettingsTableViewController {
             ),
             SettingItem(type: "switch", key: "Reader.downsampleImages", title: NSLocalizedString("DOWNSAMPLE_IMAGES", comment: "")),
             SettingItem(type: "switch", key: "Reader.cropBorders", title: NSLocalizedString("CROP_BORDERS", comment: "")),
-            SettingItem(type: "switch", key: "Reader.saveImageOption", title: NSLocalizedString("SAVE_IMAGE_OPTION", comment: ""))
+            SettingItem(type: "switch", key: "Reader.saveImageOption", title: NSLocalizedString("SAVE_IMAGE_OPTION", comment: "")),
+            SettingItem(
+                type: "select",
+                key: "Reader.backgroundColor",
+                title: NSLocalizedString("READER_BG_COLOR", comment: ""),
+                values: ["system", "white", "black"],
+                titles: [
+                    NSLocalizedString("READER_BG_COLOR_SYSTEM", comment: ""),
+                    NSLocalizedString("READER_BG_COLOR_WHITE", comment: ""),
+                    NSLocalizedString("READER_BG_COLOR_BLACK", comment: "")
+                ]
+            )
         ])])
     }
 

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -236,7 +236,18 @@ class SettingsViewController: SettingsTableViewController {
                 ),
                 SettingItem(type: "switch", key: "Reader.downsampleImages", title: NSLocalizedString("DOWNSAMPLE_IMAGES", comment: "")),
                 SettingItem(type: "switch", key: "Reader.cropBorders", title: NSLocalizedString("CROP_BORDERS", comment: "")),
-                SettingItem(type: "switch", key: "Reader.saveImageOption", title: NSLocalizedString("SAVE_IMAGE_OPTION", comment: ""))
+                SettingItem(type: "switch", key: "Reader.saveImageOption", title: NSLocalizedString("SAVE_IMAGE_OPTION", comment: "")),
+                SettingItem(
+                    type: "select",
+                    key: "Reader.backgroundColor",
+                    title: NSLocalizedString("READER_BG_COLOR", comment: ""),
+                    values: ["system", "white", "black"],
+                    titles: [
+                        NSLocalizedString("READER_BG_COLOR_SYSTEM", comment: ""),
+                        NSLocalizedString("READER_BG_COLOR_WHITE", comment: ""),
+                        NSLocalizedString("READER_BG_COLOR_BLACK", comment: "")
+                    ]
+                )
             ]),
             ReaderPagedViewModel.settings,
             ReaderWebtoonViewModel.settings,

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -469,7 +469,14 @@ extension ReaderViewController {
             UIView.animate(withDuration: CATransaction.animationDuration()) {
                 navigationController.navigationBar.alpha = 0
                 navigationController.toolbar.alpha = 0
-                self.view.backgroundColor = .black
+                self.view.backgroundColor = switch UserDefaults.standard.string(forKey: "Reader.pageBackgroundColor") {
+                case "system":
+                    .systemBackground
+                case "light":
+                    .white
+                default:
+                    .black
+                }
             } completion: { _ in
                 navigationController.toolbar.isHidden = true
             }

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -469,10 +469,10 @@ extension ReaderViewController {
             UIView.animate(withDuration: CATransaction.animationDuration()) {
                 navigationController.navigationBar.alpha = 0
                 navigationController.toolbar.alpha = 0
-                self.view.backgroundColor = switch UserDefaults.standard.string(forKey: "Reader.pageBackgroundColor") {
+                self.view.backgroundColor = switch UserDefaults.standard.string(forKey: "Reader.backgroundColor") {
                 case "system":
                     .systemBackground
-                case "light":
+                case "white":
                     .white
                 default:
                     .black

--- a/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
+++ b/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
@@ -35,17 +35,6 @@ class ReaderPagedViewModel {
                     NSLocalizedString("DOUBLE_PAGE", comment: ""),
                     NSLocalizedString("AUTOMATIC", comment: "")
                 ]
-            ),
-            SettingItem(
-                type: "select",
-                key: "Reader.pageBackgroundColor",
-                title: NSLocalizedString("PAGE_BG_COLOR", comment: ""),
-                values: ["system", "light", "dark"],
-                titles: [
-                    NSLocalizedString("PAGE_BG_COLOR_SYSTEM", comment: ""),
-                    NSLocalizedString("PAGE_BG_COLOR_LIGHT", comment: ""),
-                    NSLocalizedString("PAGE_BG_COLOR_DARK", comment: "")
-                ]
             )
         ])
     }

--- a/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
+++ b/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
@@ -35,6 +35,17 @@ class ReaderPagedViewModel {
                     NSLocalizedString("DOUBLE_PAGE", comment: ""),
                     NSLocalizedString("AUTOMATIC", comment: "")
                 ]
+            ),
+            SettingItem(
+                type: "select",
+                key: "Reader.pageBackgroundColor",
+                title: NSLocalizedString("PAGE_BG_COLOR", comment: ""),
+                values: ["system", "light", "dark"],
+                titles: [
+                    NSLocalizedString("PAGE_BG_COLOR_SYSTEM", comment: ""),
+                    NSLocalizedString("PAGE_BG_COLOR_LIGHT", comment: ""),
+                    NSLocalizedString("PAGE_BG_COLOR_DARK", comment: "")
+                ]
             )
         ])
     }


### PR DESCRIPTION
This PR introduces settings for page reader background color. 

Users can choose from three options: system theme (dark or light), light, or dark. The default value is dark, respecting the original default dark background but users can change it anytime. Additionally, English translation is included. 

The aim of this PR is to address the problem described in: [Issue 77](https://github.com/Aidoku/Aidoku/issues/77).