### PR TITLE
Improve image loading for downloaded images

### DIFF
--- a/Shared/Data/Downloads/DownloadManager.swift
+++ b/Shared/Data/Downloads/DownloadManager.swift
@@ -66,6 +66,19 @@ class DownloadManager {
         return pages.sorted { $0.index < $1.index }
     }
 
+    func getDownloadedPagesWithoutContents(for chapter: Chapter) -> [Page] {
+        cache.directory(for: chapter).contents
+            .compactMap { url in
+                Page(
+                    sourceId: chapter.sourceId,
+                    chapterId: chapter.id,
+                    index: (Int(url.deletingPathExtension().lastPathComponent) ?? 1) - 1,
+                    imageURL: url.absoluteString
+                )
+            }
+            .sorted { $0.index < $1.index }
+    }
+
     func isChapterDownloaded(chapter: Chapter) -> Bool {
         cache.isChapterDownloaded(chapter: chapter)
     }

--- a/Shared/Sources/Source.swift
+++ b/Shared/Sources/Source.swift
@@ -361,6 +361,14 @@ extension Source {
         return await actor.getPageList(chapter: chapter)
     }
 
+    func getPageListWithoutContents(chapter: Chapter) async throws -> [Page] {
+        if await DownloadManager.shared.isChapterDownloaded(chapter: chapter) {
+            return await DownloadManager.shared.getDownloadedPagesWithoutContents(for: chapter)
+        }
+
+        return await actor.getPageList(chapter: chapter)
+    }
+
     func getImageRequest(url: String) async throws -> WasmRequestObject {
         try await actor.getImageRequest(url: url)
     }

--- a/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
+++ b/iOS/UI/Reader/Readers/Paged/ReaderPagedViewModel.swift
@@ -50,14 +50,14 @@ class ReaderPagedViewModel {
                 preloadedPages = pages
             }
             self.chapter = chapter
-            pages = (try? await SourceManager.shared.source(for: chapter.sourceId)?.getPageList(chapter: chapter)) ?? []
+            pages = (try? await SourceManager.shared.source(for: chapter.sourceId)?.getPageListWithoutContents(chapter: chapter)) ?? []
         }
     }
 
     func preload(chapter: Chapter) async {
         guard preloadedChapter != chapter else { return }
         preloadedChapter = nil
-        preloadedPages = (try? await SourceManager.shared.source(for: chapter.sourceId)?.getPageList(chapter: chapter)) ?? []
+        preloadedPages = (try? await SourceManager.shared.source(for: chapter.sourceId)?.getPageListWithoutContents(chapter: chapter)) ?? []
         preloadedChapter = chapter
     }
 }


### PR DESCRIPTION
I've modified the page fetching behavior for image loading to skip reading the contents of downloaded images and creating a base64 string out of it.

I'm not familiar with most of the codebase, but from what I've browsed, it seems Aidoku uses base64 strings to encode images from sources via Wasm. This is used during the downloading process, but effectively unused when displaying downloaded pages.

The inspiration for this change came out of Aidoku's handling of large chapters. Because base64 is effectively compressed data, it doesn't serve well when many large images are stored in memory. In my experience, the memory usage causes iOS to kill the app past 2 GB (iPhone 12), as well as create a long delay prior to loading images.

Closes #359 