### PR TITLE
Only add a download to queue if it doesn't already exist

### DIFF
--- a/Shared/Data/Downloads/DownloadQueue.swift
+++ b/Shared/Data/Downloads/DownloadQueue.swift
@@ -63,6 +63,9 @@ actor DownloadQueue {
     func add(chapters: [Chapter], manga: Manga? = nil, autoStart: Bool = true) async -> [Download] {
         var downloads: [Download] = []
         for chapter in chapters {
+            if await cache.isChapterDownloaded(chapter: chapter) {
+                continue
+            }
             // create tmp directory so we know it's queued
             await cache.directory(forSourceId: chapter.sourceId, mangaId: chapter.mangaId)
                 .appendingSafePathComponent(".tmp_\(chapter.id)")


### PR DESCRIPTION
Right now, downloads are added to queue regardless if they're already downloaded or not, which takes up unneeded space in the download queue dialog.

This commit adds a check in the function for adding them, to skip if it's already downloaded.