### PR TITLE
Add option to delete downloaded chapter after reading

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -203,6 +203,7 @@
 "ONLY_DOWNLOAD_ON_WIFI" = "Only Download on Wi-Fi";
 "EXCLUDED_CATEGORIES" = "Excluded Categories";
 "REFRESH_METADATA" = "Refresh Metadata";
+"DELETE_DOWNLOAD_AFTER_READING" = "Delete Download After Reading";
 "NEVER" = "Never";
 "EVERY_12_HOURS" = "Every 12 hours";
 "DAILY" = "Daily";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -99,6 +99,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Library.excludedUpdateCategories": [String](),
                 "Library.updateOnlyOnWifi": true,
                 "Library.refreshMetadata": false,
+                "Library.deleteDownloadAfterReading": false,
 
                 "Browse.languages": ["multi"] + Locale.preferredLanguages.map { Locale(identifier: $0).languageCode },
                 "Browse.updateCount": 0,

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -197,6 +197,11 @@ class SettingsViewController: SettingsTableViewController {
                     type: "switch",
                     key: "Library.refreshMetadata",
                     title: NSLocalizedString("REFRESH_METADATA", comment: "")
+                ),
+                SettingItem(
+                    type: "switch",
+                    key: "Library.deleteDownloadAfterReading",
+                    title: NSLocalizedString("DELETE_DOWNLOAD_AFTER_READING", comment: "")
                 )
             ]),
             // MARK: Browse

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -425,6 +425,9 @@ extension ReaderViewController: ReaderHoldingDelegate {
                 await HistoryManager.shared.addHistory(chapters: [chapter])
             }
         }
+        if UserDefaults.standard.bool(forKey: "Library.deleteDownloadAfterReading") {
+            DownloadManager.shared.delete(chapters: [chapter])
+        }
     }
 }
 


### PR DESCRIPTION
This PR closes #304 (enhancement).

After a user reads a downloaded chapter, the chapter will be deleted. I added a toggle in the Settings under Library Updating which is set off by default.

This is my first time pushing to prod, let me know if there's anything I should change.