### PR TITLE
Add warning message when chapters are being skipped

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "CURRENT_COLON" = "Current:";
 "NO_NEXT_CHAPTER" = "There is no next chapter";
 "NO_PREVIOUS_CHAPTER" = "There is no previous chapter";
+"SKIPPING_CHAPTERS" = "WARNING: Chapters are being skipped. Either the source is missing them or they are filtered out.";
 "READER_SETTINGS" = "Reader Settings";
 "READING_MODE" = "Reading Mode";
 "DEFAULT" = "Default";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -136,7 +136,7 @@
 "CURRENT_COLON" = "Current:";
 "NO_NEXT_CHAPTER" = "There is no next chapter";
 "NO_PREVIOUS_CHAPTER" = "There is no previous chapter";
-"SKIPPING_CHAPTERS" = "WARNING: Chapters are being skipped. Either the source is missing them or they are filtered out.";
+"SKIPPING_CHAPTERS" = "Skipping %i chapters, either the source is missing them or they have been filtered out";
 "READER_SETTINGS" = "Reader Settings";
 "READING_MODE" = "Reading Mode";
 "DEFAULT" = "Default";

--- a/iOS/Old UI/Reader/ReaderInfoPageView.swift
+++ b/iOS/Old UI/Reader/ReaderInfoPageView.swift
@@ -32,6 +32,7 @@ class ReaderInfoPageView: UIView {
     }
 
     let noChapterLabel = UILabel()
+    let skippingChaptersView = UIStackView()
     let skippingChaptersLabel = UILabel()
 
     let stackView = UIStackView()
@@ -63,6 +64,20 @@ class ReaderInfoPageView: UIView {
         topChapterTitleLabel.font = .systemFont(ofSize: 16)
         topChapterTitleLabel.numberOfLines = 0
 
+        skippingChaptersView.distribution = .equalSpacing
+        skippingChaptersView.axis = .horizontal
+        skippingChaptersView.spacing = 8
+        skippingChaptersLabel.textColor = .secondaryLabel
+        skippingChaptersLabel.textAlignment = .left
+        skippingChaptersLabel.font = .systemFont(ofSize: 16)
+        skippingChaptersLabel.numberOfLines = 0
+        skippingChaptersLabel.preferredMaxLayoutWidth = 200
+        skippingChaptersLabel.translatesAutoresizingMaskIntoConstraints = false
+        let warningIconView = UIImageView(image: UIImage(systemName: "exclamationmark.triangle.fill"))
+        warningIconView.tintColor = .systemYellow
+        warningIconView.translatesAutoresizingMaskIntoConstraints = false
+        warningIconView.contentMode = .center
+
         let bottomStackView = UIStackView()
         bottomStackView.distribution = .equalSpacing
         bottomStackView.axis = .vertical
@@ -75,10 +90,13 @@ class ReaderInfoPageView: UIView {
 
         topStackView.addArrangedSubview(topChapterLabel)
         topStackView.addArrangedSubview(topChapterTitleLabel)
+        skippingChaptersView.addArrangedSubview(warningIconView)
+        skippingChaptersView.addArrangedSubview(skippingChaptersLabel)
         bottomStackView.addArrangedSubview(bottomChapterLabel)
         bottomStackView.addArrangedSubview(bottomChapterTitleLabel)
 
         stackView.addArrangedSubview(topStackView)
+        stackView.addArrangedSubview(skippingChaptersView)
         stackView.addArrangedSubview(bottomStackView)
 
         addSubview(stackView)
@@ -92,19 +110,6 @@ class ReaderInfoPageView: UIView {
         noChapterLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         noChapterLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
-        skippingChaptersLabel.textColor = .secondaryLabel
-        skippingChaptersLabel.textAlignment = .center
-        skippingChaptersLabel.font = .systemFont(ofSize: 14)
-        skippingChaptersLabel.numberOfLines = 0
-        skippingChaptersLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(skippingChaptersLabel)
-
-        skippingChaptersLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        skippingChaptersLabel.topAnchor.constraint(equalTo: bottomStackView.bottomAnchor, constant: 20).isActive = true
-        skippingChaptersLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20).isActive = true
-        skippingChaptersLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20).isActive = true
-
         stackView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         stackView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
         stackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 1, constant: -64).isActive = true
@@ -116,8 +121,8 @@ class ReaderInfoPageView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func areChaptersSkipped(higherChapterNumber: Float, lowerChapterNumber: Float ) -> Bool {
-        floor(higherChapterNumber) - floor(lowerChapterNumber) > 1
+    func chapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float ) -> Int {
+        Int(floor(higherChapterNumber) - floor(lowerChapterNumber)) - 1
     }
 
     func updateLabelText() {
@@ -149,13 +154,14 @@ class ReaderInfoPageView: UIView {
             }
             if let currChapterNum = currentChapter.chapterNum,
                let prevChapterNum = previousChapter.chapterNum {
-                let shouldSkipChapters = areChaptersSkipped(higherChapterNumber: currChapterNum, lowerChapterNumber: prevChapterNum)
-                skippingChaptersLabel.isHidden = !shouldSkipChapters
+                let chapterDifference = chapterDifference(higherChapterNumber: currChapterNum, lowerChapterNumber: prevChapterNum)
+                let shouldSkipChapters = chapterDifference > 1
+                skippingChaptersView.isHidden = !shouldSkipChapters
                 if shouldSkipChapters {
-                    skippingChaptersLabel.text = NSLocalizedString("SKIPPING_CHAPTERS", comment: "")
+                    skippingChaptersLabel.text = String(format: NSLocalizedString("SKIPPING_CHAPTERS", comment: ""), chapterDifference)
                 }
             } else {
-                skippingChaptersLabel.isHidden = true
+                skippingChaptersView.isHidden = true
             }
             noChapterLabel.isHidden = true
             stackView.isHidden = false
@@ -186,13 +192,14 @@ class ReaderInfoPageView: UIView {
             }
             if let currChapterNum = currentChapter.chapterNum,
                let nextChapterNum = nextChapter.chapterNum {
-                let shouldSkipChapters = areChaptersSkipped(higherChapterNumber: nextChapterNum, lowerChapterNumber: currChapterNum)
-                skippingChaptersLabel.isHidden = !shouldSkipChapters
+                let chapterDifference = chapterDifference(higherChapterNumber: nextChapterNum, lowerChapterNumber: currChapterNum)
+                let shouldSkipChapters = chapterDifference > 1
+                skippingChaptersView.isHidden = !shouldSkipChapters
                 if shouldSkipChapters {
-                    skippingChaptersLabel.text = NSLocalizedString("SKIPPING_CHAPTERS", comment: "")
+                    skippingChaptersLabel.text = String(format: NSLocalizedString("SKIPPING_CHAPTERS", comment: ""), chapterDifference)
                 }
             } else {
-                skippingChaptersLabel.isHidden = true
+                skippingChaptersView.isHidden = true
             }
             noChapterLabel.isHidden = true
             stackView.isHidden = false
@@ -201,7 +208,7 @@ class ReaderInfoPageView: UIView {
                 : NSLocalizedString("NO_NEXT_CHAPTER", comment: "")
             stackView.isHidden = true
             noChapterLabel.isHidden = false
-            skippingChaptersLabel.isHidden = true
+            skippingChaptersView.isHidden = true
         }
     }
 }

--- a/iOS/Old UI/Reader/ReaderInfoPageView.swift
+++ b/iOS/Old UI/Reader/ReaderInfoPageView.swift
@@ -32,6 +32,7 @@ class ReaderInfoPageView: UIView {
     }
 
     let noChapterLabel = UILabel()
+    let skippingChaptersLabel = UILabel()
 
     let stackView = UIStackView()
     let topChapterLabel = UILabel()
@@ -91,6 +92,19 @@ class ReaderInfoPageView: UIView {
         noChapterLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         noChapterLabel.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
+        skippingChaptersLabel.textColor = .secondaryLabel
+        skippingChaptersLabel.textAlignment = .center
+        skippingChaptersLabel.font = .systemFont(ofSize: 14)
+        skippingChaptersLabel.numberOfLines = 0
+        skippingChaptersLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(skippingChaptersLabel)
+
+        skippingChaptersLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        skippingChaptersLabel.topAnchor.constraint(equalTo: bottomStackView.bottomAnchor, constant: 20).isActive = true
+        skippingChaptersLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20).isActive = true
+        skippingChaptersLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20).isActive = true
+
         stackView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         stackView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
         stackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: 1, constant: -64).isActive = true
@@ -100,6 +114,10 @@ class ReaderInfoPageView: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func areChaptersSkipped(higherChapterNumber: Float, lowerChapterNumber: Float ) -> Bool {
+        floor(higherChapterNumber) - floor(lowerChapterNumber) > 1
     }
 
     func updateLabelText() {
@@ -129,6 +147,16 @@ class ReaderInfoPageView: UIView {
                     currentChapter.chapterNum ?? 0
                 )
             }
+            if let currChapterNum = currentChapter.chapterNum,
+               let prevChapterNum = previousChapter.chapterNum {
+                let shouldSkipChapters = areChaptersSkipped(higherChapterNumber: currChapterNum, lowerChapterNumber: prevChapterNum)
+                skippingChaptersLabel.isHidden = !shouldSkipChapters
+                if shouldSkipChapters {
+                    skippingChaptersLabel.text = NSLocalizedString("SKIPPING_CHAPTERS", comment: "")
+                }
+            } else {
+                skippingChaptersLabel.isHidden = true
+            }
             noChapterLabel.isHidden = true
             stackView.isHidden = false
         } else if let nextChapter = nextChapter {
@@ -156,6 +184,16 @@ class ReaderInfoPageView: UIView {
                     nextChapter.chapterNum ?? 0
                 )
             }
+            if let currChapterNum = currentChapter.chapterNum,
+               let nextChapterNum = nextChapter.chapterNum {
+                let shouldSkipChapters = areChaptersSkipped(higherChapterNumber: nextChapterNum, lowerChapterNumber: currChapterNum)
+                skippingChaptersLabel.isHidden = !shouldSkipChapters
+                if shouldSkipChapters {
+                    skippingChaptersLabel.text = NSLocalizedString("SKIPPING_CHAPTERS", comment: "")
+                }
+            } else {
+                skippingChaptersLabel.isHidden = true
+            }
             noChapterLabel.isHidden = true
             stackView.isHidden = false
         } else {
@@ -163,6 +201,7 @@ class ReaderInfoPageView: UIView {
                 : NSLocalizedString("NO_NEXT_CHAPTER", comment: "")
             stackView.isHidden = true
             noChapterLabel.isHidden = false
+            skippingChaptersLabel.isHidden = true
         }
     }
 }

--- a/iOS/Old UI/Reader/ReaderInfoPageView.swift
+++ b/iOS/Old UI/Reader/ReaderInfoPageView.swift
@@ -71,7 +71,6 @@ class ReaderInfoPageView: UIView {
         skippingChaptersLabel.textAlignment = .left
         skippingChaptersLabel.font = .systemFont(ofSize: 16)
         skippingChaptersLabel.numberOfLines = 0
-        skippingChaptersLabel.preferredMaxLayoutWidth = 200
         skippingChaptersLabel.translatesAutoresizingMaskIntoConstraints = false
         let warningIconView = UIImageView(image: UIImage(systemName: "exclamationmark.triangle.fill"))
         warningIconView.tintColor = .systemYellow
@@ -121,13 +120,13 @@ class ReaderInfoPageView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func chapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float ) -> Int {
-        Int(floor(higherChapterNumber) - floor(lowerChapterNumber)) - 1
+    func chapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float) -> Int {
+        Int(floor(higherChapterNumber) - floor(lowerChapterNumber))
     }
 
     func updateLabelText() {
-        guard let currentChapter = currentChapter else { return }
-        if let previousChapter = previousChapter {
+        guard let currentChapter else { return }
+        if let previousChapter {
             topChapterLabel.text = NSLocalizedString("PREVIOUS_COLON", comment: "")
             if let previousTitle = previousChapter.title {
                 topChapterTitleLabel.text = String(
@@ -165,7 +164,7 @@ class ReaderInfoPageView: UIView {
             }
             noChapterLabel.isHidden = true
             stackView.isHidden = false
-        } else if let nextChapter = nextChapter {
+        } else if let nextChapter {
             topChapterLabel.text = NSLocalizedString("FINISHED_COLON", comment: "")
             if let currentTitle = currentChapter.title {
                 topChapterTitleLabel.text = String(


### PR DESCRIPTION
This closes #212 

A new UI label is added and displays when a chapter difference bigger than 1 is detected after going to a new chapter. Let me know if the text or styling should be changed. Maybe a warning icon should be displayed?

<img width="404" alt="image" src="https://github.com/Aidoku/Aidoku/assets/52114668/36b52cde-8e27-4d07-9408-3bda4729d994">
