### PR TITLE
Add action for clearing history excluding mangas in library

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "REMOVE" = "Remove";
 "RENAME" = "Rename";
 "CLEAR" = "Clear";
+"CLEAR_EXCLUDING_LIBRARY" = "Clear Excluding Library";
 "PAUSE" = "Pause";
 "RESUME" = "Resume";
 "LOADING_ELLIPSIS" = "Loading…";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -17,7 +17,6 @@
 "REMOVE" = "Remove";
 "RENAME" = "Rename";
 "CLEAR" = "Clear";
-"CLEAR_EXCLUDING_LIBRARY" = "Clear Excluding Library";
 "PAUSE" = "Pause";
 "RESUME" = "Resume";
 "LOADING_ELLIPSIS" = "Loading…";
@@ -263,6 +262,8 @@
 "CLEAR_NETWORK_CACHE_TEXT" = "This action is irreversible. Cached network requests and images will be cleared.";
 "CLEAR_READ_HISTORY" = "Clear Read History";
 "CLEAR_READ_HISTORY_TEXT" = "This action is irreversible. All read history will be removed.";
+"CLEAR_EXCLUDING_LIBRARY" = "Clear Read History Excluding Library";
+"CLEAR_EXCLUDING_LIBRARY_TEXT" = "This action is irreversible. All read history excluding the library will be removed.";
 "RESET_SETTINGS" = "Reset Settings";
 "RESET_SETTINGS_TEXT" = "This action is irreversible. All app and source settings will be reset.";
 "PAGE_X_OF_X" = "Page %i of %i";

--- a/Shared/Managers/CoreData/CoreDataManager+History.swift
+++ b/Shared/Managers/CoreData/CoreDataManager+History.swift
@@ -14,6 +14,20 @@ extension CoreDataManager {
         clear(request: HistoryObject.fetchRequest(), context: context)
     }
 
+    /// Remove all history objects from manga not in library
+    func clearHistoryExcludingLibrary(context: NSManagedObjectContext? = nil) {
+        let context = context ?? self.context
+        let request = HistoryObject.fetchRequest()
+        let libraryMangaIds = self.getLibraryManga(context: context).compactMap {
+            $0.manga?.toManga().id
+        }
+        request.predicate = NSPredicate(
+            format: "NOT (mangaId IN %@)",
+            libraryMangaIds
+        )
+        clear(request: request, context: context)
+    }
+
     /// Gets all history objects.
     func getHistory(context: NSManagedObjectContext? = nil) -> [HistoryObject] {
         (try? (context ?? self.context).fetch(HistoryObject.fetchRequest())) ?? []

--- a/iOS/Old UI/History/HistoryViewController.swift
+++ b/iOS/Old UI/History/HistoryViewController.swift
@@ -149,6 +149,7 @@ class HistoryViewController: UIViewController {
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.queueRefresh = true
+                self?.reloadHistory()
             }
         })
         observers.append(NotificationCenter.default.addObserver(

--- a/iOS/Old UI/History/HistoryViewController.swift
+++ b/iOS/Old UI/History/HistoryViewController.swift
@@ -438,17 +438,6 @@ class HistoryViewController: UIViewController {
         }
         alertView.addAction(action)
 
-        let action2 = UIAlertAction(title: NSLocalizedString("CLEAR_EXCLUDING_LIBRARY", comment: ""), style: .destructive) { _ in
-            Task { @MainActor in
-                await CoreDataManager.shared.container.performBackgroundTask { context in
-                    CoreDataManager.shared.clearHistoryExcludingLibrary(context: context)
-                    try? context.save()
-                }
-                self.reloadHistory()
-            }
-        }
-        alertView.addAction(action2)
-
         alertView.addAction(UIAlertAction(title: NSLocalizedString("CANCEL", comment: ""), style: .cancel))
         present(alertView, animated: true)
     }

--- a/iOS/Old UI/History/HistoryViewController.swift
+++ b/iOS/Old UI/History/HistoryViewController.swift
@@ -438,6 +438,17 @@ class HistoryViewController: UIViewController {
         }
         alertView.addAction(action)
 
+        let action2 = UIAlertAction(title: NSLocalizedString("CLEAR_EXCLUDING_LIBRARY", comment: ""), style: .destructive) { _ in
+            Task { @MainActor in
+                await CoreDataManager.shared.container.performBackgroundTask { context in
+                    CoreDataManager.shared.clearHistoryExcludingLibrary(context: context)
+                    try? context.save()
+                }
+                self.reloadHistory()
+            }
+        }
+        alertView.addAction(action2)
+
         alertView.addAction(UIAlertAction(title: NSLocalizedString("CANCEL", comment: ""), style: .cancel))
         present(alertView, animated: true)
     }

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -290,6 +290,7 @@ class SettingsViewController: SettingsTableViewController {
                 SettingItem(type: "button", key: "Advanced.clearTrackedManga", title: NSLocalizedString("CLEAR_TRACKED_MANGA", comment: "")),
                 SettingItem(type: "button", key: "Advanced.clearNetworkCache", title: NSLocalizedString("CLEAR_NETWORK_CACHE", comment: "")),
                 SettingItem(type: "button", key: "Advanced.clearReadHistory", title: NSLocalizedString("CLEAR_READ_HISTORY", comment: "")),
+                SettingItem(type: "button", key: "Advanced.clearExcludingLibrary", title: NSLocalizedString("CLEAR_EXCLUDING_LIBRARY", comment: "")),
                 SettingItem(type: "button", key: "Advanced.migrateHistory", title: "Migrate Chapter History"),
                 SettingItem(type: "button", key: "Advanced.resetSettings", title: NSLocalizedString("RESET_SETTINGS", comment: "")),
                 SettingItem(type: "button", key: "Advanced.reset", title: NSLocalizedString("RESET", comment: ""), destructive: true)
@@ -472,6 +473,18 @@ extension SettingsViewController {
                     Task {
                         await CoreDataManager.shared.container.performBackgroundTask { context in
                             CoreDataManager.shared.clearHistory(context: context)
+                            try? context.save()
+                        }
+                    }
+                }
+            case "Advanced.clearExcludingLibrary":
+                confirmAction(
+                    title: NSLocalizedString("CLEAR_EXCLUDING_LIBRARY", comment: ""),
+                    message: NSLocalizedString("CLEAR_EXCLUDING_LIBRARY_TEXT", comment: "")
+                ) {
+                    Task {
+                        await CoreDataManager.shared.container.performBackgroundTask { context in
+                            CoreDataManager.shared.clearHistoryExcludingLibrary(context: context)
                             try? context.save()
                         }
                     }

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -475,6 +475,7 @@ extension SettingsViewController {
                             CoreDataManager.shared.clearHistory(context: context)
                             try? context.save()
                         }
+                        NotificationCenter.default.post(name: Notification.Name("updateHistory"), object: nil)
                     }
                 }
             case "Advanced.clearExcludingLibrary":
@@ -487,6 +488,7 @@ extension SettingsViewController {
                             CoreDataManager.shared.clearHistoryExcludingLibrary(context: context)
                             try? context.save()
                         }
+                        NotificationCenter.default.post(name: Notification.Name("updateHistory"), object: nil)
                     }
                 }
             case "Advanced.migrateHistory":


### PR DESCRIPTION
This closes #210 

On the history tab, I added a new action for clearing all history outside of manga in the user's library.
<img width="396" alt="image" src="https://github.com/Aidoku/Aidoku/assets/52114668/db559fe5-63e3-416a-9167-a4cef7ea1853">

Should this new action be added to Settings on "Clear Read History"? Also, let me know if the string or anything else should be changed.
