### PR TITLE
Migrate can now be accessed within the library directly

### DIFF
--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -975,6 +975,15 @@ extension LibraryViewController {
                 })
             }
 
+            actions.append(UIAction(
+                title: NSLocalizedString("MIGRATE", comment: ""),
+                image: UIImage(systemName: "arrow.left.arrow.right")
+            ) { [weak self] _ in
+                let manga = manga.toManga()
+                let migrateView = MigrateMangaView(manga: [manga])
+                self?.present(UIHostingController(rootView: SwiftUINavigationView(rootView: AnyView(migrateView))), animated: true)
+            })
+
             if let url = manga.url {
                 actions.append(UIAction(
                     title: NSLocalizedString("SHARE", comment: ""),


### PR DESCRIPTION
This adds "Migrate" to the right-click menu within the Library