### PR TITLE
Mark all as read/unread can now be accessed within the library directly

### DIFF
--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -975,6 +975,31 @@ extension LibraryViewController {
                 })
             }
 
+            actions.append(UIMenu(title: NSLocalizedString("MARK_ALL", comment: ""), image: nil, children: [
+                // read chapters
+                UIAction(title: NSLocalizedString("READ", comment: ""), image: UIImage(systemName: "eye")) { _ in
+                    self.showLoadingIndicator()
+                    Task {
+                        let manga = manga.toManga()
+                        let chapters = await CoreDataManager.shared.getChapters(sourceId: manga.sourceId, mangaId: manga.id)
+
+                        await HistoryManager.shared.addHistory(chapters: chapters)
+                        self.hideLoadingIndicator()
+                    }
+                },
+                // unread chapters
+                UIAction(title: NSLocalizedString("UNREAD", comment: ""), image: UIImage(systemName: "eye.slash")) { _ in
+                    self.showLoadingIndicator()
+                    Task {
+                        let manga = manga.toManga()
+                        let chapters = await CoreDataManager.shared.getChapters(sourceId: manga.sourceId, mangaId: manga.id)
+
+                        await HistoryManager.shared.removeHistory(chapters: chapters)
+                        self.hideLoadingIndicator()
+                    }
+                }
+            ]))
+
             if let url = manga.url {
                 actions.append(UIAction(
                     title: NSLocalizedString("SHARE", comment: ""),


### PR DESCRIPTION
This adds a "Mark All" sub-menu to the Library view's right click menu