### PR TITLE
Mark skipped duplicate chapters as read

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -335,6 +335,7 @@
 "RENAME_CATEGORY_INFO" = "Enter a new name for this category.";
 "RENAME_CATEGORY_FAIL" = "Failed to Rename Category";
 "SKIP_DUPLICATE_CHAPTERS" = "Skip Duplicate Chapters";
+"MARK_SKIPPED_CHAPTERS" = "Mark Skipped Chapters as Read";
 "RENAME_CATEGORY" = "Rename Category";
 "RENAME_CATEGORY_FAIL_INFO" = "Category names must be unique.";
 "CATEGORY_NAME" = "Category Name";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -115,6 +115,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 "Reader.readingMode": "auto",
                 "Reader.skipDuplicateChapters": true,
+                "Reader.markSkippedChapters": true,
                 "Reader.downsampleImages": true,
                 "Reader.cropBorders": false,
                 "Reader.saveImageOption": true,

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -244,6 +244,12 @@ class SettingsViewController: SettingsTableViewController {
                     key: "Reader.skipDuplicateChapters",
                     title: NSLocalizedString("SKIP_DUPLICATE_CHAPTERS", comment: "")
                 ),
+                SettingItem(
+                    type: "switch",
+                    key: "Reader.markSkippedChapters",
+                    title: NSLocalizedString("MARK_SKIPPED_CHAPTERS", comment: ""),
+                    requires: "Reader.skipDuplicateChapters"
+                ),
                 SettingItem(type: "switch", key: "Reader.downsampleImages", title: NSLocalizedString("DOWNSAMPLE_IMAGES", comment: "")),
                 SettingItem(type: "switch", key: "Reader.cropBorders", title: NSLocalizedString("CROP_BORDERS", comment: "")),
                 SettingItem(type: "switch", key: "Reader.saveImageOption", title: NSLocalizedString("SAVE_IMAGE_OPTION", comment: "")),

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -370,13 +370,14 @@ extension ReaderViewController: ReaderHoldingDelegate {
             return nil
         }
         let skipDuplicates = UserDefaults.standard.bool(forKey: "Reader.skipDuplicateChapters")
+        let markSkipped = UserDefaults.standard.bool(forKey: "Reader.markSkippedChapters")
         index -= 1
         while index >= 0 {
             let new = chapterList[index]
             if !skipDuplicates || (new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum) {
                 return new
             }
-            if skipDuplicates {
+            if skipDuplicates && markSkipped {
                 chaptersToMark.append(new)
             }
             index -= 1

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -20,6 +20,7 @@ class ReaderViewController: BaseObservingViewController {
     var defaultReadingMode: ReadingMode?
 
     var chapterList: [Chapter] = []
+    var chaptersToMark: [Chapter] = []
     var currentPage = 1
 
     weak var reader: ReaderReaderDelegate?
@@ -56,6 +57,7 @@ class ReaderViewController: BaseObservingViewController {
     init(chapter: Chapter, chapterList: [Chapter] = [], defaultReadingMode: ReadingMode? = nil) {
         self.chapter = chapter
         self.chapterList = chapterList
+        self.chaptersToMark = [chapter]
         self.defaultReadingMode = defaultReadingMode
         super.init()
     }
@@ -374,6 +376,9 @@ extension ReaderViewController: ReaderHoldingDelegate {
             if !skipDuplicates || (new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum) {
                 return new
             }
+            if skipDuplicates {
+                chaptersToMark.append(new)
+            }
             index -= 1
         }
         return nil
@@ -424,7 +429,7 @@ extension ReaderViewController: ReaderHoldingDelegate {
     func setCompleted() {
         if !UserDefaults.standard.bool(forKey: "General.incognitoMode") {
             Task {
-                await HistoryManager.shared.addHistory(chapters: [chapter])
+                await HistoryManager.shared.addHistory(chapters: chaptersToMark)
             }
         }
         if UserDefaults.standard.bool(forKey: "Library.deleteDownloadAfterReading") {


### PR DESCRIPTION
This fixes #517

Each chapter skipped in `getNextChapter()` will be appended to `chaptersToMark`. Once a chapter is finished, it and any skipped chapters are marked as read.