### PR TITLE
fix(reader): wrong previous chapter

### DIFF
--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -389,7 +389,7 @@ extension ReaderViewController: ReaderHoldingDelegate {
         index += 1
         while index < chapterList.count {
             let new = chapterList[index]
-            if new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum {
+            if new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum || (new.chapterNum == nil && new.volumeNum == nil) {
                 return new
             }
             index += 1


### PR DESCRIPTION
This PR fixes the issue where the title-only chapters are skipped when getting previous chapter.

## Related Issues

- Closes #429

## Changes

- Fixed a bug where the previous title-only chapters were skipped if the current chapter was also title-only

## Screenshots

| Chapter List | Before | After |
| :-: | :-: | :-: |
| ![chapter-list](https://github.com/user-attachments/assets/784d06f0-afc1-430a-bd53-08eaa248e9b3) | ![before](https://github.com/user-attachments/assets/7979ef17-8fd6-46bb-be94-a4fe42c09aa3) | ![after](https://github.com/user-attachments/assets/fd5da6f1-4037-419e-93e6-246b4db6f371) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**