### PR TITLE
docs(readme): add altstore installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,21 @@ A free and open source manga reading application for iOS and iPadOS.
 - [ ] Update notifications
 
 ## Installation
-The latest ipa will always be available from the [releases page](https://github.com/Aidoku/Aidoku/releases).
 
-For detailed installation instructions, check out [the website](https://aidoku.app). To join the TestFlight, you will need to join the [Aidoku Discord](https://discord.gg/9U8cC5Zk3s).
+For detailed installation instructions, check out [the website](https://aidoku.app).
+
+### Testflight
+
+To join the TestFlight, you will need to join the [Aidoku Discord](https://discord.gg/9U8cC5Zk3s).
+
+### AltStore
+
+- [Add to AltStore](altstore://source/?url=https://raw.githubusercontent.com/Aidoku/Aidoku/altstore/apps.json).
+- Copy [source direct URL](https://raw.githubusercontent.com/Aidoku/Aidoku/altstore/apps.json) and paste to AltStore.
+
+### Manual
+
+The latest ipa will always be available from the [releases page](https://github.com/Aidoku/Aidoku/releases).
 
 ## Contributing
 Aidoku is still relatively new, and there are a lot of planned features and fixes. If you're interested in contributing, I'd first recommend checking with me on [Discord](https://discord.gg/9U8cC5Zk3s).


### PR DESCRIPTION
@Skittyblock
Not sure if you plan to update README, [website](https://aidoku.app/help/guides/getting-started/) and Discord install-info, so I just create a draft pull request.

GitHub does not render non-HTTP links, so line 23 (Add to AltStore) should be replace with something like [add-source-list](https://github.com/Aidoku/Website/blob/main/static/add-source-list/index.html).

Closes #102.
