### PR TITLE
Modify marking duplicate chapters option

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -335,7 +335,7 @@
 "RENAME_CATEGORY_INFO" = "Enter a new name for this category.";
 "RENAME_CATEGORY_FAIL" = "Failed to Rename Category";
 "SKIP_DUPLICATE_CHAPTERS" = "Skip Duplicate Chapters";
-"MARK_SKIPPED_CHAPTERS" = "Mark Skipped Chapters as Read";
+"MARK_DUPLICATE_CHAPTERS" = "Mark Duplicate Chapters as Read";
 "RENAME_CATEGORY" = "Rename Category";
 "RENAME_CATEGORY_FAIL_INFO" = "Category names must be unique.";
 "CATEGORY_NAME" = "Category Name";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -115,7 +115,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 "Reader.readingMode": "auto",
                 "Reader.skipDuplicateChapters": true,
-                "Reader.markSkippedChapters": true,
+                "Reader.markDuplicateChapters": true,
                 "Reader.downsampleImages": true,
                 "Reader.cropBorders": false,
                 "Reader.saveImageOption": true,

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -246,9 +246,8 @@ class SettingsViewController: SettingsTableViewController {
                 ),
                 SettingItem(
                     type: "switch",
-                    key: "Reader.markSkippedChapters",
-                    title: NSLocalizedString("MARK_SKIPPED_CHAPTERS", comment: ""),
-                    requires: "Reader.skipDuplicateChapters"
+                    key: "Reader.markDuplicateChapters",
+                    title: NSLocalizedString("MARK_DUPLICATE_CHAPTERS", comment: "")
                 ),
                 SettingItem(type: "switch", key: "Reader.downsampleImages", title: NSLocalizedString("DOWNSAMPLE_IMAGES", comment: "")),
                 SettingItem(type: "switch", key: "Reader.cropBorders", title: NSLocalizedString("CROP_BORDERS", comment: "")),

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -391,7 +391,10 @@ extension ReaderViewController: ReaderHoldingDelegate {
 
         while index >= 0 {
             let new = chapterList[index]
-            let isDuplicate = new.chapterNum == chapter.chapterNum && new.volumeNum == chapter.volumeNum
+            let isDuplicate =
+                new.chapterNum == chapter.chapterNum
+                && new.volumeNum == chapter.volumeNum
+                && (!(new.chapterNum == nil && new.volumeNum == nil) || new.title == chapter.title)
 
             if nextChapterInList == nil {
                 nextChapterInList = new
@@ -421,7 +424,11 @@ extension ReaderViewController: ReaderHoldingDelegate {
         index += 1
         while index < chapterList.count {
             let new = chapterList[index]
-            if new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum || (new.chapterNum == nil && new.volumeNum == nil) {
+            let isDuplicate =
+                new.chapterNum == chapter.chapterNum
+                && new.volumeNum == chapter.volumeNum
+                && (!(new.chapterNum == nil && new.volumeNum == nil) || new.title == chapter.title)
+            if !isDuplicate {
                 return new
             }
             if markDuplicates {

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -382,16 +382,27 @@ extension ReaderViewController: ReaderHoldingDelegate {
         else {
             return nil
         }
+
         let skipDuplicates = UserDefaults.standard.bool(forKey: "Reader.skipDuplicateChapters")
-        let markSkipped = UserDefaults.standard.bool(forKey: "Reader.markSkippedChapters")
+        let markDuplicates = UserDefaults.standard.bool(forKey: "Reader.markDuplicateChapters")
+
         index -= 1
+        var nextChapterInList: Chapter?
+
         while index >= 0 {
             let new = chapterList[index]
-            if !skipDuplicates || (new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum) {
-                return new
+            let isDuplicate = new.chapterNum == chapter.chapterNum && new.volumeNum == chapter.volumeNum
+
+            if nextChapterInList == nil {
+                nextChapterInList = new
             }
-            if skipDuplicates && markSkipped {
+            if markDuplicates && isDuplicate {
                 chaptersToMark.append(new)
+            }
+            if !isDuplicate {
+                return skipDuplicates ? new : nextChapterInList
+            } else if !skipDuplicates && !markDuplicates {
+                return new
             }
             index -= 1
         }
@@ -405,11 +416,16 @@ extension ReaderViewController: ReaderHoldingDelegate {
             return nil
         }
         // find previous non-duplicate chapter
+        let markDuplicates = UserDefaults.standard.bool(forKey: "Reader.markDuplicateChapters")
+
         index += 1
         while index < chapterList.count {
             let new = chapterList[index]
             if new.chapterNum != chapter.chapterNum || new.volumeNum != chapter.volumeNum || (new.chapterNum == nil && new.volumeNum == nil) {
                 return new
+            }
+            if markDuplicates {
+                chaptersToMark.append(new)
             }
             index += 1
         }
@@ -418,6 +434,7 @@ extension ReaderViewController: ReaderHoldingDelegate {
 
     func setChapter(_ chapter: Chapter) {
         self.chapter = chapter
+        self.chaptersToMark = [chapter]
         loadNavbarTitle()
     }
 


### PR DESCRIPTION
Closes #547 

- Separated "Mark Duplicated Chapters" from requiring "Skip Duplicated Chapters" to be on
- changed getPrevChapter() to mark duplicate chapters from before it
- changed getNextChapter() to handle the two different settings:
  - If not skipping dupes but marking, return the next chapter in the list and mark dupes as read
  - If skipping but not marking, return the first non-duplicate chapter and keep dupes unread
  - If neither, return the next chapter in the list in first iteration
  - If both, return the first non-duplicate chapter and mark dupes