### PR TITLE
fix(manga): title-only chapters marked as read

### DIFF
--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -451,6 +451,8 @@ class MangaViewController: BaseTableViewController {
         alert.addAction(UIAlertAction(title: NSLocalizedString("CANCEL", comment: ""), style: .cancel) { _ in })
 
         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+            var chapterList = self.viewModel.chapterList
+            chapterList.sort { $0.sourceOrder < $1.sourceOrder }
             let chapters = self.viewModel.chapterList.filter {
                 floor($0.chapterNum ?? -1) <= chapterNum
             }

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -453,6 +453,9 @@ class MangaViewController: BaseTableViewController {
         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
             var chapterList = self.viewModel.chapterList
             chapterList.sort { $0.sourceOrder < $1.sourceOrder }
+            guard let lastReadChapter = chapterList.firstIndex(where: {
+                $0.chapterNum != nil && floor($0.chapterNum!) <= chapterNum
+            }) else { return }
             let chapters = self.viewModel.chapterList.filter {
                 floor($0.chapterNum ?? -1) <= chapterNum
             }

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -456,9 +456,7 @@ class MangaViewController: BaseTableViewController {
             guard let lastReadChapter = chapterList.firstIndex(where: {
                 $0.chapterNum != nil && floor($0.chapterNum!) <= chapterNum
             }) else { return }
-            let chapters = self.viewModel.chapterList.filter {
-                floor($0.chapterNum ?? -1) <= chapterNum
-            }
+            let chapters = Array(chapterList[lastReadChapter...])
             Task {
                 await self.markRead(chapters: chapters)
             }


### PR DESCRIPTION
## Related Issues

- Closes #550

## Changes

- Fixed a bug where unread title-only chapters were marked as read when syncing with tracker

## Screenshots

| Before | After |
| :-: | :-: |
| ![before](https://github.com/user-attachments/assets/7a99a096-833e-4cf5-8d86-f1d3d74d03a3) | ![after](https://github.com/user-attachments/assets/1e6f05a1-c46f-4c00-9321-9ac6ee45d015) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**