### PR TITLE
Consistent sorting and fixes "Mark previous as read/unread"

### DIFF
--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -1037,14 +1037,19 @@ extension MangaViewController {
 
     /// Returns a "Mark Previous" submenu for the chapter cell at the specified index path.
     private func markPreviousSubmenu(at indexPath: IndexPath) -> UIMenu {
-        UIMenu(title: NSLocalizedString("MARK_PREVIOUS", comment: ""), children: [
+        func getChaptersToIndex() -> [Chapter] {
+            let chapterList = self.viewModel.chapterList
+            let row = indexPath.row
+            return viewModel.sortAscending
+                ? Array(chapterList[0..<row])
+                : Array(chapterList[row+1..<chapterList.count])
+        }
+        return UIMenu(title: NSLocalizedString("MARK_PREVIOUS", comment: ""), children: [
             UIAction(
                 title: NSLocalizedString("READ", comment: ""),
                 image: UIImage(systemName: "eye")
             ) { _ in
-                let chapters = [Chapter](self.viewModel.chapterList[
-                    indexPath.row..<self.viewModel.chapterList.count
-                ])
+                let chapters = getChaptersToIndex()
                 Task {
                     await self.markRead(chapters: chapters)
                 }
@@ -1053,9 +1058,7 @@ extension MangaViewController {
                 title: NSLocalizedString("UNREAD", comment: ""),
                 image: UIImage(systemName: "eye.slash")
             ) { _ in
-                let chapters = [Chapter](self.viewModel.chapterList[
-                    indexPath.row..<self.viewModel.chapterList.count
-                ])
+                let chapters = getChaptersToIndex()
                 Task {
                     await self.markUnread(chapters: chapters)
                 }

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -1038,10 +1038,12 @@ extension MangaViewController {
     /// Returns a "Mark Previous" submenu for the chapter cell at the specified index path.
     private func markPreviousSubmenu(at indexPath: IndexPath) -> UIMenu {
         func getChaptersToIndex() -> [Chapter] {
-            let chapterList = self.viewModel.chapterList
-            return viewModel.sortAscending
-                ? Array(chapterList[0..<indexPath.row])
-                : Array(chapterList[indexPath.row+1..<chapterList.count])
+            let chapterList = viewModel.sortAscending ? self.viewModel.chapterList : self.viewModel.chapterList.reversed()
+            guard let selectedChapter = self.dataSource.itemIdentifier(for: indexPath),
+                  let index = chapterList.firstIndex(of: selectedChapter) else {
+                return []
+            }
+            return Array(chapterList[..<index])
         }
         return UIMenu(title: NSLocalizedString("MARK_PREVIOUS", comment: ""), children: [
             UIAction(

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -1039,10 +1039,9 @@ extension MangaViewController {
     private func markPreviousSubmenu(at indexPath: IndexPath) -> UIMenu {
         func getChaptersToIndex() -> [Chapter] {
             let chapterList = self.viewModel.chapterList
-            let row = indexPath.row
             return viewModel.sortAscending
-                ? Array(chapterList[0..<row])
-                : Array(chapterList[row+1..<chapterList.count])
+                ? Array(chapterList[0..<indexPath.row])
+                : Array(chapterList[indexPath.row+1..<chapterList.count])
         }
         return UIMenu(title: NSLocalizedString("MARK_PREVIOUS", comment: ""), children: [
             UIAction(

--- a/iOS/UI/Manga/MangaViewController.swift
+++ b/iOS/UI/Manga/MangaViewController.swift
@@ -1038,7 +1038,7 @@ extension MangaViewController {
     /// Returns a "Mark Previous" submenu for the chapter cell at the specified index path.
     private func markPreviousSubmenu(at indexPath: IndexPath) -> UIMenu {
         func getChaptersToIndex() -> [Chapter] {
-            let chapterList = viewModel.sortAscending ? self.viewModel.chapterList : self.viewModel.chapterList.reversed()
+            let chapterList = viewModel.sortAscending ? viewModel.chapterList : viewModel.chapterList.reversed()
             guard let selectedChapter = self.dataSource.itemIdentifier(for: indexPath),
                   let index = chapterList.firstIndex(of: selectedChapter) else {
                 return []
@@ -1050,18 +1050,16 @@ extension MangaViewController {
                 title: NSLocalizedString("READ", comment: ""),
                 image: UIImage(systemName: "eye")
             ) { _ in
-                let chapters = getChaptersToIndex()
                 Task {
-                    await self.markRead(chapters: chapters)
+                    await self.markRead(chapters: getChaptersToIndex())
                 }
             },
             UIAction(
                 title: NSLocalizedString("UNREAD", comment: ""),
                 image: UIImage(systemName: "eye.slash")
             ) { _ in
-                let chapters = getChaptersToIndex()
                 Task {
-                    await self.markUnread(chapters: chapters)
+                    await self.markUnread(chapters: getChaptersToIndex())
                 }
             }
         ])

--- a/iOS/UI/Manga/MangaViewModel.swift
+++ b/iOS/UI/Manga/MangaViewModel.swift
@@ -245,8 +245,6 @@ class MangaViewModel {
     }
 
     func getOrderedChapterList() -> [Chapter] {
-        (sortAscending && sortMethod == .sourceOrder) || (!sortAscending && sortMethod != .sourceOrder)
-            ? filteredChapterList.reversed()
-            : filteredChapterList
+        sortAscending ? filteredChapterList.reversed() : filteredChapterList
     }
 }

--- a/iOS/UI/Manga/MangaViewModel.swift
+++ b/iOS/UI/Manga/MangaViewModel.swift
@@ -103,16 +103,16 @@ class MangaViewModel {
             }
         case .chapter:
             if ascending {
-                filteredChapterList.sort { $0.chapterNum ?? 0 > $1.chapterNum ?? 0 }
-            } else {
                 filteredChapterList.sort { $0.chapterNum ?? 0 < $1.chapterNum ?? 0 }
+            } else {
+                filteredChapterList.sort { $0.chapterNum ?? 0 > $1.chapterNum ?? 0 }
             }
         case .uploadDate:
             let now = Date()
             if ascending {
-                filteredChapterList.sort { $0.dateUploaded ?? now > $1.dateUploaded ?? now }
-            } else {
                 filteredChapterList.sort { $0.dateUploaded ?? now < $1.dateUploaded ?? now }
+            } else {
+                filteredChapterList.sort { $0.dateUploaded ?? now > $1.dateUploaded ?? now }
             }
         }
     }


### PR DESCRIPTION
Makes sure sorting in any direction/method lets you mark "previous" chapters rather than chapters below the selected one. Also avoids marking the current chapter as read/unread when using "Mark previous".

- For example, if you select chapter 10, regardless of sorting direction, chapters 0-9 will be marked.

Closes: https://github.com/Aidoku/Aidoku/issues/139

## New Behaviour
- Excludes the selected chapter when using "Mark previous"
- "Mark previous" now marks previous chapters  in terms of upload date, chapter number, and source-order.

- Sorting descending after the changes:
	- Upload date: latest to earliest
	- Chapter: latest to earliest
	- Source order: latest to earliest (same as before)
	
## Other
- Changed `MangaViewModel.getOrderedChapterList` to avoid breaking the reader.

Related: https://github.com/Aidoku/Aidoku/issues/10