### PR TITLE
Updated AltStore apps.json for missing entitlement

### DIFF
--- a/.github/workflows/supporting/altstore/apps.json
+++ b/.github/workflows/supporting/altstore/apps.json
@@ -38,6 +38,7 @@
       "appPermissions": {
         "entitlements": [
           "aps-environment",
+          "com.apple.developer.icloud-container-environment",
           "com.apple.developer.icloud-container-identifiers",
           "com.apple.developer.icloud-services",
           "com.apple.developer.ubiquity-kvstore-identifier"


### PR DESCRIPTION
Fixes the following warning.
![IMG_4540](https://github.com/user-attachments/assets/bf374517-8665-4503-a9db-2dd44e1bb074)
