### PR TITLE
fix: save webtoon reader images to album

### DIFF
--- a/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
+++ b/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
@@ -212,7 +212,7 @@ extension ReaderWebtoonViewController: UIContextMenuInteractionDelegate {
                 title: NSLocalizedString("SAVE_TO_PHOTOS", comment: ""),
                 image: UIImage(systemName: "photo")
             ) { _ in
-                UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+                image.saveToAlbum(viewController: self)
             }
             let shareAction = UIAction(
                 title: NSLocalizedString("SHARE", comment: ""),


### PR DESCRIPTION
## Changes

- Fixed an issue where images in webtoon reader were not saved to album

## Screenshots

| Before | After |
| :-: | :-: |
| ![album-before](https://github.com/user-attachments/assets/e7b83f42-d758-4c93-8ecc-1ae09c03e119) | ![album-after](https://github.com/user-attachments/assets/c180099b-d923-4b14-bb7e-58887df71df5) |
| <video src="https://github.com/user-attachments/assets/6d3821db-c761-4648-9b38-6a8d3b8effe4"> | <video src="https://github.com/user-attachments/assets/ddaa76c4-707d-4af5-bf22-7f4d9feae0c2"> |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
