### PR TITLE
feat(library): undo remove from category

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -1,9 +1,9 @@
-/* 
+/*
   Localizable.strings
   Aidoku
 
   Created by Skitty on 4/23/22.
-  
+
 */
 
 // General
@@ -55,6 +55,8 @@
 "LATEST_CHAPTER" = "Latest Chapter";
 "DATE_ADDED" = "Date Added";
 "COVER" = "Cover";
+"REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@" = "Removing Manga from Category %@";
+"REMOVING_%i_MANGA_FROM_CATEGORY_%@" = "Removing %i Manga from Category %@";
 
 // Categories
 "ALL" = "All";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -55,8 +55,8 @@
 "LATEST_CHAPTER" = "Latest Chapter";
 "DATE_ADDED" = "Date Added";
 "COVER" = "Cover";
-"REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@" = "Removing Manga from Category %@";
-"REMOVING_%i_MANGA_FROM_CATEGORY_%@" = "Removing %i Manga from Category %@";
+"REMOVING_(ONE)_ITEM_FROM_CATEGORY_%@" = "Removing Item from Category %@";
+"REMOVING_%i_ITEMS_FROM_CATEGORY_%@" = "Removing %i Items from Category %@";
 
 // Categories
 "ALL" = "All";

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -174,6 +174,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
+        application.applicationSupportsShakeToEdit = true
+
         return true
     }
 

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -53,6 +53,10 @@ class LibraryViewController: MangaCollectionViewController {
     private var ignoreOptionChange = false
     private var lastSearch: String?
 
+    private let libraryUndoManager = UndoManager()
+    override var undoManager: UndoManager { libraryUndoManager }
+    override var canBecomeFirstResponder: Bool { true }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -68,6 +72,8 @@ class LibraryViewController: MangaCollectionViewController {
         if viewModel.shouldUpdateLibrary() {
             updateLibraryRefresh()
         }
+
+        becomeFirstResponder()
     }
 
     override func viewDidLoad() {

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -963,7 +963,6 @@ extension LibraryViewController {
         return manga[path.row]
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     func collectionView(
         _ collectionView: UICollectionView,
         contextMenuConfigurationForItemsAt indexPaths: [IndexPath],

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1168,10 +1168,10 @@ extension LibraryViewController {
         let actionName =
             mangaCount > 1
             ? String(
-                format: NSLocalizedString("REMOVING_%i_MANGA_FROM_CATEGORY_%@", comment: ""),
+                format: NSLocalizedString("REMOVING_%i_ITEMS_FROM_CATEGORY_%@", comment: ""),
                 mangaCount, currentCategory)
             : String(
-                format: NSLocalizedString("REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@", comment: ""),
+                format: NSLocalizedString("REMOVING_(ONE)_ITEM_FROM_CATEGORY_%@", comment: ""),
                 currentCategory)
         undoManager.setActionName(actionName)
 

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -562,7 +562,7 @@ class LibraryViewController: MangaCollectionViewController {
                 ) { _ in
                     Task {
                         let identifiers = selectedItems.compactMap { self.dataSource.itemIdentifier(for: $0) }
-                        await self.removeFromCategory(mangaInfo: identifiers).value
+                        await self.removeFromCategory(mangaInfo: identifiers)?.value
                         self.updateNavbarItems()
                         self.updateToolbar()
                     }
@@ -1162,16 +1162,17 @@ extension LibraryViewController: UISearchResultsUpdating {
 // MARK: - Undoable Methods
 extension LibraryViewController {
     @discardableResult
-    func removeFromCategory(mangaInfo: [MangaInfo]) -> Task<Void, Never> {
+    func removeFromCategory(mangaInfo: [MangaInfo]) -> Task<Void, Never>? {
+        guard let currentCategory = viewModel.currentCategory else { return nil }
         let mangaCount = mangaInfo.count
         let actionName =
             mangaCount > 1
             ? String(
                 format: NSLocalizedString("REMOVING_%i_MANGA_FROM_CATEGORY_%@", comment: ""),
-                mangaCount, viewModel.currentCategory!)
+                mangaCount, currentCategory)
             : String(
                 format: NSLocalizedString("REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@", comment: ""),
-                viewModel.currentCategory!)
+                currentCategory)
         undoManager.setActionName(actionName)
         undoManager.registerUndo(withTarget: self) { target in
             target.undoManager.registerUndo(withTarget: target) { redoTarget in

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1164,6 +1164,16 @@ extension LibraryViewController: UISearchResultsUpdating {
 extension LibraryViewController {
     @discardableResult
     func removeFromCategory(mangaInfo: [MangaInfo]) -> Task<Void, Never> {
+        let mangaCount = mangaInfo.count
+        let actionName =
+            mangaCount > 1
+            ? String(
+                format: NSLocalizedString("REMOVING_%i_MANGA_FROM_CATEGORY_%@", comment: ""),
+                mangaCount, viewModel.currentCategory!)
+            : String(
+                format: NSLocalizedString("REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@", comment: ""),
+                viewModel.currentCategory!)
+        undoManager.setActionName(actionName)
         undoManager.registerUndo(withTarget: self) { target in
             target.undoManager.registerUndo(withTarget: target) { redoTarget in
                 redoTarget.removeFromCategory(mangaInfo: mangaInfo)

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1174,6 +1174,7 @@ extension LibraryViewController {
                 format: NSLocalizedString("REMOVING_(ONE)_MANGA_FROM_CATEGORY_%@", comment: ""),
                 currentCategory)
         undoManager.setActionName(actionName)
+
         undoManager.registerUndo(withTarget: self) { target in
             target.undoManager.registerUndo(withTarget: target) { redoTarget in
                 redoTarget.removeFromCategory(mangaInfo: mangaInfo)

--- a/iOS/UI/Library/LibraryViewModel.swift
+++ b/iOS/UI/Library/LibraryViewModel.swift
@@ -478,6 +478,15 @@ class LibraryViewModel {
         await MangaManager.shared.removeFromLibrary(sourceId: manga.sourceId, mangaId: manga.mangaId)
     }
 
+    func addToCurrentCategory(manga: MangaInfo) async {
+        guard let currentCategory = currentCategory else { return }
+        await CoreDataManager.shared.addCategoriesToManga(
+            sourceId: manga.sourceId,
+            mangaId: manga.mangaId,
+            categories: [currentCategory]
+        )
+    }
+
     func removeFromCurrentCategory(manga: MangaInfo) async {
         guard let currentCategory = currentCategory else { return }
         pinnedManga.removeAll { $0.mangaId == manga.mangaId && $0.sourceId == manga.sourceId }


### PR DESCRIPTION
## Related Issues

- #79

## Changes

- Added support for undoing and redoing removing manga from category

## Screenshots/Screen Recordings

https://github.com/user-attachments/assets/61fea331-9720-46db-b7a8-76689faf8087

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
