### PR TITLE
Hide Tab Bar when Tool Bar is shown in Library

### DIFF
--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -498,6 +498,10 @@ extension LibraryViewController {
                 UIView.animate(withDuration: 0.3) {
                     self.navigationController?.isToolbarHidden = false
                     self.navigationController?.toolbar.alpha = 1
+                    if #available(iOS 26.0, *) {
+                        // hide tab bar on iOS 26 (it covers the toolbar)
+                        self.tabBarController?.isTabBarHidden = true
+                    }
                 }
             }
             // show add to category button if categories exist
@@ -524,6 +528,10 @@ extension LibraryViewController {
             // fade out toolbar
             UIView.animate(withDuration: 0.3) {
                 self.navigationController?.toolbar.alpha = 0
+                if #available(iOS 26.0, *) {
+                    // reshow tab bar on iOS 26
+                    self.rootNavigation.navigationController?.tabBarController?.isTabBarHidden = false
+                }
             } completion: { _ in
                 self.navigationController?.isToolbarHidden = true
             }

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -530,7 +530,7 @@ extension LibraryViewController {
                 self.navigationController?.toolbar.alpha = 0
                 if #available(iOS 26.0, *) {
                     // reshow tab bar on iOS 26
-                    self.rootNavigation.navigationController?.tabBarController?.isTabBarHidden = false
+                    self.tabBarController?.isTabBarHidden = false
                 }
             } completion: { _ in
                 self.navigationController?.isToolbarHidden = true


### PR DESCRIPTION
This fixes this issue: [https://github.com/Aidoku/Aidoku/issues/663](https://github.com/Aidoku/Aidoku/issues/663)

Before (delete and add to category buttons at bottom are obscured by tab bar):
<img width="250" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-26 at 02 57 55" src="https://github.com/user-attachments/assets/fe1b3a12-fda0-44b6-a74a-3b9863ed6ba0" />

After:
<img width="250" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-26 at 02 56 53" src="https://github.com/user-attachments/assets/186ffebc-3073-4e2a-818d-25354f49cff9" />

