### PR TITLE
fix: buggy lock library/history button in Settings

### DIFF
--- a/Shared/Sources/SettingItem.swift
+++ b/Shared/Sources/SettingItem.swift
@@ -26,7 +26,6 @@ struct SettingItem: Codable {
     var requires: String?
     var requiresFalse: String?
 
-    var authToEnable: Bool?
     var authToDisable: Bool?
     var authToOpen: Bool?
 
@@ -70,7 +69,6 @@ struct SettingItem: Codable {
         case requires
         case requiresFalse
 
-        case authToEnable
         case authToDisable
         case authToOpen
 

--- a/iOS/Old UI/Base/Settings/SettingsTableViewController.swift
+++ b/iOS/Old UI/Base/Settings/SettingsTableViewController.swift
@@ -98,21 +98,6 @@ extension SettingsTableViewController {
                         }
                     }
                 }
-            } else if item.authToEnable ?? false && isOn {
-                let context = LAContext()
-                if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
-                    context.evaluatePolicy(
-                        .deviceOwnerAuthenticationWithBiometrics,
-                        localizedReason: NSLocalizedString("AUTH_TO_ENABLE", comment: "")
-                    ) { success, _ in
-                        if !success {
-                            Task { @MainActor in
-                                switchView.setOn(false, animated: true)
-                                switchView.sendActions(for: .valueChanged)
-                            }
-                        }
-                    }
-                }
             }
             if let notification = item.notification {
                 self.source?.performAction(key: notification)

--- a/iOS/Old UI/Settings/SettingsViewController.swift
+++ b/iOS/Old UI/Settings/SettingsViewController.swift
@@ -126,7 +126,6 @@ class SettingsViewController: SettingsTableViewController {
                     key: "Library.lockLibrary",
                     title: NSLocalizedString("LOCK_LIBRARY", comment: ""),
                     notification: "updateLibraryLock",
-                    authToEnable: true,
                     authToDisable: true
                 )
             ]),
@@ -220,7 +219,6 @@ class SettingsViewController: SettingsTableViewController {
                     type: "switch",
                     key: "History.lockHistoryTab",
                     title: NSLocalizedString("LOCK_HISTORY_TAB", comment: ""),
-                    authToEnable: true,
                     authToDisable: true
                 )
             ]),


### PR DESCRIPTION
## Related Issues:
* Closes #660
* Closes #383

## Recording:
https://github.com/user-attachments/assets/2e584ea3-1ee4-41ea-adac-d6c4f4a22f1a

## Changes:
* Removed `var authToEnable` entirely.
* Require authentication only when Lock Library or Lock History Tab is _disabled_.

i know this change might be a bit iffy for some (it was for me too), but after doing some digging around other apps, this implementation is not unusual. for example, this scheme is used for locking the Hidden and Recently Deleted albums in the Photos app. Go to Settings > Apps > Photos > Use Face ID:

https://github.com/user-attachments/assets/da040aa1-2efc-4209-8c3e-b37275ed5267



