### PR TITLE
fix: hide bars when scene enters foreground

### DIFF
--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -241,7 +241,9 @@ class ReaderViewController: BaseObservingViewController {
         }
         if #available(iOS 26.0, *) {
             addObserver(forName: UIScene.willEnterForegroundNotification) { [weak self] _ in
-                self?.hideBars()
+                if self?.navigationController?.toolbar.alpha == 0 {
+                    self?.hideBars()
+                }
             }
         }
     }

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -234,6 +234,10 @@ class ReaderViewController: BaseObservingViewController {
         addObserver(forName: UIScene.willDeactivateNotification) { [weak self] _ in
             guard let self else { return }
             self.updateReadPosition()
+
+            if #available(iOS 26.0, *) {
+                statusBarHidden = false
+            }
         }
     }
 

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -239,6 +239,11 @@ class ReaderViewController: BaseObservingViewController {
                 statusBarHidden = false
             }
         }
+        if #available(iOS 26.0, *) {
+            addObserver(forName: UIScene.willEnterForegroundNotification) { [weak self] _ in
+                self?.hideBars()
+            }
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
This PR provides a band-aid fix for the bug where the navigation bar overlaps the status bar.

## Related Issues/Pull Requests

- Closes #682

## Screenshots/Screen Recordings

| Before | After |
| :-: | :-: |
| ![before](https://github.com/user-attachments/assets/5135361c-d893-43bd-bae8-2bbf8ee8a74f) | ![after](https://github.com/user-attachments/assets/72a7570c-a63b-444a-a931-77220f9867ab) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
