### PR TITLE
fix: add titles to browse menu items.

### DIFF
--- a/iOS/UI/Browse/BrowseViewController.swift
+++ b/iOS/UI/Browse/BrowseViewController.swift
@@ -521,19 +521,25 @@ extension BrowseViewController {
                 navigationItem.rightBarButtonItems = [UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(stopEditing))]
             }
         } else {
+            let addSourceBarButton = UIBarButtonItem(
+                image: UIImage(systemName: "plus"),
+                style: .plain,
+                target: self,
+                action: #selector(openAddSourcePage)
+            )
+            addSourceBarButton.title = NSLocalizedString("ADD_SOURCE")
+
+            let migrateSourcesBarButton = UIBarButtonItem(
+                image: UIImage(systemName: "arrow.left.arrow.right"),
+                style: .plain,
+                target: self,
+                action: #selector(openMigrateSourcePage)
+            )
+            migrateSourcesBarButton.title = NSLocalizedString("MIGRATE_SOURCES")
+
             navigationItem.rightBarButtonItems = [
-                UIBarButtonItem(
-                    image: UIImage(systemName: "plus"),
-                    style: .plain,
-                    target: self,
-                    action: #selector(openAddSourcePage)
-                ),
-                UIBarButtonItem(
-                    image: UIImage(systemName: "arrow.left.arrow.right"),
-                    style: .plain,
-                    target: self,
-                    action: #selector(openMigrateSourcePage)
-                )
+                addSourceBarButton,
+                migrateSourcesBarButton
             ]
         }
     }


### PR DESCRIPTION
These are rendered as a menu on iPad, and they look really weird without text.

Before:
<img width="456" height="92" alt="Screenshot 2025-09-28 at 3 03 32 PM" src="https://github.com/user-attachments/assets/e14cb9b3-03ea-4823-83b7-6b1d5dbf04ff" />


After:
<img width="456" height="92" alt="Screenshot 2025-09-28 at 3 04 07 PM" src="https://github.com/user-attachments/assets/5fbcc5ac-ab69-43f1-9107-1f9c3c223432" />
