### PR TITLE
fix: the description is incorrect & allows description, author and tag to be copied

### DIFF
--- a/iOS/New/Views/Manga/ExpandableTextView.swift
+++ b/iOS/New/Views/Manga/ExpandableTextView.swift
@@ -24,7 +24,7 @@ struct ExpandableTextView: View {
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .prefix(4)
             .prefix { !$0.isEmpty && !$0.contains("___") }
-            .joined(separator: "\n")
+            .joined(separator: "  \n")
     }
 
     static let markdownTheme = Theme()
@@ -67,6 +67,7 @@ struct ExpandableTextView: View {
                 .font(.subheadline)
                 .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
                 .id(expanded ? "1" : "0") // removes sliding from animation
                 .background(GeometryReader { geometry in
                     Color.clear

--- a/iOS/New/Views/Manga/MangaDetailsHeaderView.swift
+++ b/iOS/New/Views/Manga/MangaDetailsHeaderView.swift
@@ -136,6 +136,7 @@ struct MangaDetailsHeaderView: View {
                             .foregroundStyle(.secondary)
                             .font(.callout)
                             .padding(.bottom, 6)
+                            .textSelection(.enabled)
                             .transition(.opacity)
 
                         if let source, source.supportsAuthorSearch {
@@ -495,6 +496,7 @@ private struct TagView: View {
             .font(.footnote)
             .padding(.horizontal, 12)
             .padding(.vertical, 5)
+            .textSelection(.enabled)
             .background(Color(UIColor.tertiarySystemFill))
             .clipShape(RoundedRectangle(cornerRadius: 100))
     }


### PR DESCRIPTION
The author and tag reproduction is used for sources prior to version 0.7, and there is no cost to add it.

The text in the description should allow selection and copying, and existing controls don't seem to simply achieve this.