### PR TITLE
fix: correct clear souce cache i18n key

### DIFF
--- a/iOS/New/Views/Source/SourceSettingsView.swift
+++ b/iOS/New/Views/Source/SourceSettingsView.swift
@@ -56,7 +56,7 @@ struct SourceSettingsView: View {
             }
 
             Section {
-                Button(NSLocalizedString("Clear Source Cache")) {
+                Button(NSLocalizedString("CLEAR_SOURCE_CACHE")) {
                     showingClearCacheConfirm = true
                 }
 


### PR DESCRIPTION
## Changes

- Fixed an issue where the `Clear Source Cache` button in source setting was not properly localised
  | Before | After |
  | :-: | :-: |
  | ![before-setting](https://github.com/user-attachments/assets/d568b94a-39eb-409c-9d77-d20b994afdc5) | ![after-setting](https://github.com/user-attachments/assets/dd72d283-bea3-405e-85c1-b161ef62e06c) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
