### PR TITLE
fix: use inline title for `AddSourceView`

### DIFF
--- a/iOS/New/Views/Browse/AddSourceView.swift
+++ b/iOS/New/Views/Browse/AddSourceView.swift
@@ -184,6 +184,7 @@ struct AddSourceView: View {
                 }
             }
             .navigationTitle(NSLocalizedString("ADD_SOURCE"))
+            .navigationBarTitleDisplayMode(.inline)
             .onReceive(NotificationCenter.default.publisher(for: .browseLanguages)) { _ in
                 // re-filter external sources when selected languages change
                 let result = filterExternalSources()


### PR DESCRIPTION
## Premise

The `navigationBarTitleDisplayMode` for `AddSourceView` is not set to `inline`, which is inconsistent with the other sheet views (e.g. `MigrateSourcesView`).

## Changes

- Fixed an issue where the navigation title of `AddSourceView` was not inline
  | Before | After |
  | :-: | :-: |
  | ![add_source-before](https://github.com/user-attachments/assets/25f0697e-622d-4e4d-84c0-e6bb9f943bcb) | ![add_source-after](https://github.com/user-attachments/assets/e5386947-cd01-4cf4-88d8-145403e2cab8) |

## Notes

**Please let me know if there are any issues with this PR. Thanks for taking the time to review!**
