### PR TITLE
fix: ComicInfo.xml, specifically, should be in the root of a zip file.

### DIFF
--- a/Shared/Data/Downloads/DownloadManager.swift
+++ b/Shared/Data/Downloads/DownloadManager.swift
@@ -164,7 +164,7 @@ actor DownloadManager {
         let tmpFile = FileManager.default.temporaryDirectory?.appendingPathComponent(chapterFile.lastPathComponent)
         guard let tmpFile else { return nil }
         do {
-            try FileManager.default.zipItem(at: chapterDirectory, to: tmpFile)
+            try FileManager.default.zipItem(at: chapterDirectory, to: tmpFile, shouldKeepParent: false)
             return tmpFile
         } catch {
             return nil

--- a/Shared/Data/Downloads/DownloadTask.swift
+++ b/Shared/Data/Downloads/DownloadTask.swift
@@ -382,7 +382,7 @@ extension DownloadTask {
                 try FileManager.default.moveItem(at: tmpDirectory, to: directory)
 
                 if UserDefaults.standard.bool(forKey: "Downloads.compress") {
-                    try FileManager.default.zipItem(at: directory, to: directory.appendingPathExtension("cbz"))
+                    try FileManager.default.zipItem(at: directory, to: directory.appendingPathExtension("cbz"), shouldKeepParent: false)
                     directory.removeItem()
                 }
 


### PR DESCRIPTION
Without this, `.cbz` files will lack visible metadata in external programs