### PR TITLE
fix: XML requires that quotes and apostrophes be escaped

### DIFF
--- a/Shared/Models/ComicInfo.swift
+++ b/Shared/Models/ComicInfo.swift
@@ -334,6 +334,8 @@ extension ComicInfo {
             escaped = escaped.replacingOccurrences(of: "&", with: "&amp;")
             escaped = escaped.replacingOccurrences(of: "<", with: "&lt;")
             escaped = escaped.replacingOccurrences(of: ">", with: "&gt;")
+            escaped = escaped.replacingOccurrences(of: "\"", with: "&quot;")
+            escaped = escaped.replacingOccurrences(of: "'", with: "&apos;")
             return escaped
         }
 


### PR DESCRIPTION
per the [spec](https://www.w3.org/TR/REC-xml/#syntax):
`To allow attribute values to contain both single and double quotes, the apostrophe or single-quote character (') may be represented as " &apos; ", and the double-quote character (") as " &quot; ".`