### PR TITLE
Fix/scanlator affinity

### DIFF
--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -595,6 +595,11 @@ extension ReaderViewController: ReaderHoldingDelegate {
             && (!(a.chapterNumber == nil && a.volumeNumber == nil) || a.title == b.title)
     }
 
+    private func isValidScanlatorMatch(for next: AidokuRunner.Chapter, current: Set<String>) -> Bool {
+        let nextScanlators = Set(next.scanlators ?? [])
+        return current.isEmpty ? nextScanlators.isEmpty : !current.isDisjoint(with: nextScanlators)
+    }
+
     private func findBestChapterMatch(from index: Int, step: Int) -> AidokuRunner.Chapter {
         let firstCandidate = chapterList[index]
         let currentScanlators = Set(chapter.scanlators ?? [])
@@ -607,11 +612,8 @@ extension ReaderViewController: ReaderHoldingDelegate {
             let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: next.key)
             let isReadable = !next.locked || DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
 
-            if isReadable {
-                let nextScanlators = Set(next.scanlators ?? [])
-                if currentScanlators.isEmpty ? nextScanlators.isEmpty : !currentScanlators.isDisjoint(with: nextScanlators) {
-                    return next
-                }
+            if isReadable && isValidScanlatorMatch(for: next, current: currentScanlators) {
+                return next
             }
             i += step
         }


### PR DESCRIPTION
when reading a source that has multiple chapter sources, it was annoying that the default behavior was to choose the first in the list of the next chapter. This change enhances the reader to pick the same chapter source that the reader is using for example,  if user pick scanlator 4, and there is 1,2,3,5 instead of the default behavior being to choose the first available source. This change will attempt to pick the same scanlator 4 chapter source instead of picking scanlator 1 if not then go back to default choose first available.

I was also thinking of maybe adding a drop down menu to the reader settings for the default behavior of choosing the scanlator persistence or not but I dont think that is needed... as the current implementation just reverts back to the default select first available source... 


