### PR TITLE
fix(komga): tags display on the `oneShot` type book details page is incomplete

### DIFF
--- a/Shared/Sources/Komga/KomgaModels.swift
+++ b/Shared/Sources/Komga/KomgaModels.swift
@@ -304,6 +304,7 @@ struct KomgaSeries: Codable, Sendable {
     struct BooksMetadata: Codable, Sendable {
         let authors: [KomgaBook.Metadata.Author]
         let summary: String?
+        let tags: [String]
     }
 
     let id: String
@@ -312,6 +313,7 @@ struct KomgaSeries: Codable, Sendable {
     let metadata: Metadata
     let booksMetadata: BooksMetadata
     let booksCount: Int
+    let oneshot: Bool?
 }
 
 extension KomgaSeries {
@@ -361,7 +363,7 @@ extension KomgaSeries {
             description: (metadata.summary.isEmpty ? booksMetadata.summary : metadata.summary)?
                 .replacingOccurrences(of: "\n", with: "  \n"),
             url: URL(string: "series/\(id)", relativeTo: baseUrl),
-            tags: (metadata.genres + metadata.tags).sorted(),
+            tags: (oneshot == true ? (metadata.genres + booksMetadata.tags) : (metadata.genres + metadata.tags)).sorted(),
             status: status,
             contentRating: contentRating,
             viewer: viewer,


### PR DESCRIPTION
Before:
<img width="585" height="1210" alt="图片" src="https://github.com/user-attachments/assets/f4193f84-f9e0-4391-8782-2412debd567d" />

After:
<img width="585" height="1205" alt="图片" src="https://github.com/user-attachments/assets/664dfaa0-9e29-4cc8-b4ce-df108e86c4e4" />
