### PR TITLE
Resume most recently opened chapter from Start Reading

### DIFF
--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -431,6 +431,7 @@
 "LANDSCAPE" = "Landscape";
 "READER" = "Reader";
 "OPEN_READER_VIEW" = "Open Reader View";
+"RESUME_LAST_OPENED_CHAPTER" = "Resume Last Opened Chapter";
 "UNREAD_CHAPTER_BADGES" = "Unread Chapter Badges";
 "DOWNLOADED_CHAPTER_BADGES" = "Downloaded Chapter Badges";
 "PIN_TITLES" = "Pin Titles";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -431,7 +431,6 @@
 "LANDSCAPE" = "Landscape";
 "READER" = "Reader";
 "OPEN_READER_VIEW" = "Open Reader View";
-"RESUME_LAST_OPENED_CHAPTER" = "Resume Last Opened Chapter";
 "UNREAD_CHAPTER_BADGES" = "Unread Chapter Badges";
 "DOWNLOADED_CHAPTER_BADGES" = "Downloaded Chapter Badges";
 "PIN_TITLES" = "Pin Titles";

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -27,6 +27,28 @@ actor MangaManager {
 
     private static let maxConcurrentLibraryUpdateTasks = 10
 
+    nonisolated func getLastOpenedChapter(
+        manga: AidokuRunner.Manga,
+        chapters: [AidokuRunner.Chapter],
+        readingHistory: [String: (page: Int, date: Int)]
+    ) -> AidokuRunner.Chapter? {
+        var lastOpenedChapter: AidokuRunner.Chapter?
+        var lastOpenedDate: Int = -1
+
+        for chapter in chapters {
+            if let history = readingHistory[chapter.id] {
+                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
+                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
+                if !chapter.locked || isDownloaded, history.date > lastOpenedDate {
+                    lastOpenedDate = history.date
+                    lastOpenedChapter = chapter
+                }
+            }
+        }
+
+        return lastOpenedChapter
+    }
+
     nonisolated func getNextChapter(
         manga: AidokuRunner.Manga,
         chapters: [AidokuRunner.Chapter],

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -27,54 +27,36 @@ actor MangaManager {
 
     private static let maxConcurrentLibraryUpdateTasks = 10
 
-    nonisolated func getLastOpenedChapter(
-        manga: AidokuRunner.Manga,
-        chapters: [AidokuRunner.Chapter],
-        readingHistory: [String: (page: Int, date: Int)]
-    ) -> AidokuRunner.Chapter? {
-        var lastOpenedChapter: AidokuRunner.Chapter?
-        var lastOpenedDate: Int = -1
-
-        for chapter in chapters {
-            if let history = readingHistory[chapter.id] {
-                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
-                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
-                if !chapter.locked || isDownloaded, history.date > lastOpenedDate {
-                    lastOpenedDate = history.date
-                    lastOpenedChapter = chapter
-                }
-            }
-        }
-
-        return lastOpenedChapter
-    }
-
     nonisolated func getNextChapter(
         manga: AidokuRunner.Manga,
         chapters: [AidokuRunner.Chapter],
         readingHistory: [String: (page: Int, date: Int)],
         sortAscending: Bool
     ) -> AidokuRunner.Chapter? {
-        // 1. Resume Reading: Find the most recently read chapter that isn't completed
-        var lastReadChapter: AidokuRunner.Chapter?
-        var lastReadDate: Int = -1
+        let resumeLastOpened = UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
+
+        // 1. Resume Reading: Find the most recently read chapter that isn't
+        // completed, unless the "resume last opened" option is enabled.
+        var selectedChapter: AidokuRunner.Chapter?
+        var selectedDate: Int = -1
 
         for chapter in chapters {
-            if let history = readingHistory[chapter.id], history.page != -1 {
-                // Ensure chapter is accessible
-                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
-                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
-                if !chapter.locked || isDownloaded {
-                    if history.date > lastReadDate {
-                        lastReadDate = history.date
-                        lastReadChapter = chapter
-                    }
-                }
+            guard let history = readingHistory[chapter.id] else { continue }
+
+            let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
+            let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
+            guard !chapter.locked || isDownloaded else { continue }
+
+            guard resumeLastOpened || history.page != -1 else { continue }
+
+            if history.date > selectedDate {
+                selectedDate = history.date
+                selectedChapter = chapter
             }
         }
 
-        if let lastReadChapter {
-            return lastReadChapter
+        if let selectedChapter {
+            return selectedChapter
         }
 
         // 2. Fallback: Find first uncompleted chapter in sort order (Start Reading)

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -33,27 +33,26 @@ actor MangaManager {
         readingHistory: [String: (page: Int, date: Int)],
         sortAscending: Bool
     ) -> AidokuRunner.Chapter? {
-        // 1. Resume Reading: reopen the most recently opened chapter, even if it
-        // was completed, so skipped chapters do not override the reader's latest position.
-        var lastOpenedChapter: AidokuRunner.Chapter?
-        var lastOpenedDate: Int = -1
+        // 1. Resume Reading: Find the most recently read chapter that isn't completed
+        var lastReadChapter: AidokuRunner.Chapter?
+        var lastReadDate: Int = -1
 
         for chapter in chapters {
-            if let history = readingHistory[chapter.id] {
+            if let history = readingHistory[chapter.id], history.page != -1 {
                 // Ensure chapter is accessible
                 let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
                 let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
                 if !chapter.locked || isDownloaded {
-                    if history.date > lastOpenedDate {
-                        lastOpenedDate = history.date
-                        lastOpenedChapter = chapter
+                    if history.date > lastReadDate {
+                        lastReadDate = history.date
+                        lastReadChapter = chapter
                     }
                 }
             }
         }
 
-        if let lastOpenedChapter {
-            return lastOpenedChapter
+        if let lastReadChapter {
+            return lastReadChapter
         }
 
         // 2. Fallback: Find first uncompleted chapter in sort order (Start Reading)

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -31,33 +31,32 @@ actor MangaManager {
         manga: AidokuRunner.Manga,
         chapters: [AidokuRunner.Chapter],
         readingHistory: [String: (page: Int, date: Int)],
-        sortAscending: Bool,
-        resumeLastOpenedChapter: Bool = false
+        sortAscending: Bool
     ) -> AidokuRunner.Chapter? {
-        if resumeLastOpenedChapter {
-            // Resume the most recently opened chapter, even if it was completed.
-            var lastOpenedChapter: AidokuRunner.Chapter?
-            var lastOpenedDate: Int = -1
+        // 1. Resume Reading: reopen the most recently opened chapter, even if it
+        // was completed, so skipped chapters do not override the reader's latest position.
+        var lastOpenedChapter: AidokuRunner.Chapter?
+        var lastOpenedDate: Int = -1
 
-            for chapter in chapters {
-                if let history = readingHistory[chapter.id] {
-                    let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
-                    let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
-                    if !chapter.locked || isDownloaded {
-                        if history.date > lastOpenedDate {
-                            lastOpenedDate = history.date
-                            lastOpenedChapter = chapter
-                        }
+        for chapter in chapters {
+            if let history = readingHistory[chapter.id] {
+                // Ensure chapter is accessible
+                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
+                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
+                if !chapter.locked || isDownloaded {
+                    if history.date > lastOpenedDate {
+                        lastOpenedDate = history.date
+                        lastOpenedChapter = chapter
                     }
                 }
             }
-
-            if let lastOpenedChapter {
-                return lastOpenedChapter
-            }
         }
 
-        // Find first uncompleted chapter in sort order (default Start Reading behavior)
+        if let lastOpenedChapter {
+            return lastOpenedChapter
+        }
+
+        // 2. Fallback: Find first uncompleted chapter in sort order (Start Reading)
         let sorted = sortAscending ? chapters : chapters.reversed()
 
         return sorted.first(where: { chapter in

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -31,32 +31,33 @@ actor MangaManager {
         manga: AidokuRunner.Manga,
         chapters: [AidokuRunner.Chapter],
         readingHistory: [String: (page: Int, date: Int)],
-        sortAscending: Bool
+        sortAscending: Bool,
+        resumeLastOpenedChapter: Bool = false
     ) -> AidokuRunner.Chapter? {
-        // 1. Resume Reading: reopen the most recently opened chapter, even if it
-        // was completed, so skipped chapters do not override the reader's latest position.
-        var lastOpenedChapter: AidokuRunner.Chapter?
-        var lastOpenedDate: Int = -1
+        if resumeLastOpenedChapter {
+            // Resume the most recently opened chapter, even if it was completed.
+            var lastOpenedChapter: AidokuRunner.Chapter?
+            var lastOpenedDate: Int = -1
 
-        for chapter in chapters {
-            if let history = readingHistory[chapter.id] {
-                // Ensure chapter is accessible
-                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
-                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
-                if !chapter.locked || isDownloaded {
-                    if history.date > lastOpenedDate {
-                        lastOpenedDate = history.date
-                        lastOpenedChapter = chapter
+            for chapter in chapters {
+                if let history = readingHistory[chapter.id] {
+                    let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
+                    let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
+                    if !chapter.locked || isDownloaded {
+                        if history.date > lastOpenedDate {
+                            lastOpenedDate = history.date
+                            lastOpenedChapter = chapter
+                        }
                     }
                 }
             }
+
+            if let lastOpenedChapter {
+                return lastOpenedChapter
+            }
         }
 
-        if let lastOpenedChapter {
-            return lastOpenedChapter
-        }
-
-        // 2. Fallback: Find first uncompleted chapter in sort order (Start Reading)
+        // Find first uncompleted chapter in sort order (default Start Reading behavior)
         let sorted = sortAscending ? chapters : chapters.reversed()
 
         return sorted.first(where: { chapter in

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -41,18 +41,20 @@ actor MangaManager {
         var selectedDate: Int = -1
 
         for chapter in chapters {
-            guard let history = readingHistory[chapter.id] else { continue }
+            guard
+                let history = readingHistory[chapter.id],
+                resumeLastOpened || history.page != -1,
+                history.date > selectedDate
+            else { continue }
 
-            let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
-            let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
-            guard !chapter.locked || isDownloaded else { continue }
-
-            guard resumeLastOpened || history.page != -1 else { continue }
-
-            if history.date > selectedDate {
-                selectedDate = history.date
-                selectedChapter = chapter
+            if chapter.locked {
+                let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
+                let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
+                guard isDownloaded else { continue }
             }
+
+            selectedDate = history.date
+            selectedChapter = chapter
         }
 
         if let selectedChapter {

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -33,26 +33,27 @@ actor MangaManager {
         readingHistory: [String: (page: Int, date: Int)],
         sortAscending: Bool
     ) -> AidokuRunner.Chapter? {
-        // 1. Resume Reading: Find the most recently read chapter that isn't completed
-        var lastReadChapter: AidokuRunner.Chapter?
-        var lastReadDate: Int = -1
+        // 1. Resume Reading: reopen the most recently opened chapter, even if it
+        // was completed, so skipped chapters do not override the reader's latest position.
+        var lastOpenedChapter: AidokuRunner.Chapter?
+        var lastOpenedDate: Int = -1
 
         for chapter in chapters {
-            if let history = readingHistory[chapter.id], history.page != -1 {
+            if let history = readingHistory[chapter.id] {
                 // Ensure chapter is accessible
                 let identifier = ChapterIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
                 let isDownloaded = DownloadManager.shared.getDownloadStatus(for: identifier) == .finished
                 if !chapter.locked || isDownloaded {
-                    if history.date > lastReadDate {
-                        lastReadDate = history.date
-                        lastReadChapter = chapter
+                    if history.date > lastOpenedDate {
+                        lastOpenedDate = history.date
+                        lastOpenedChapter = chapter
                     }
                 }
             }
         }
 
-        if let lastReadChapter {
-            return lastReadChapter
+        if let lastOpenedChapter {
+            return lastOpenedChapter
         }
 
         // 2. Fallback: Find first uncompleted chapter in sort order (Start Reading)

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -124,6 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Library.lastUpdated": Date.distantPast.timeIntervalSince1970,
 
                 "Library.opensReaderView": false,
+                "Library.resumeLastOpenedChapter": false,
                 "Library.unreadChapterBadges": true,
                 "Library.downloadedChapterBadges": true,
                 "Library.pinTitles": LibraryViewModel.PinType.none.rawValue,

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -124,7 +124,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 "Library.lastUpdated": Date.distantPast.timeIntervalSince1970,
 
                 "Library.opensReaderView": false,
-                "Library.resumeLastOpenedChapter": false,
                 "Library.unreadChapterBadges": true,
                 "Library.downloadedChapterBadges": true,
                 "Library.pinTitles": LibraryViewModel.PinType.none.rawValue,

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -795,27 +795,12 @@ extension MangaView.ViewModel {
     private func getNextChapter() -> ChapterResult {
         guard !chapters.isEmpty else { return .none }
 
-        let resumeLastOpened = UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
-
-        let chapter = if resumeLastOpened {
-            MangaManager.shared.getLastOpenedChapter(
-                manga: manga,
-                chapters: chapters,
-                readingHistory: readingHistory
-            ) ?? MangaManager.shared.getNextChapter(
-                manga: manga,
-                chapters: chapters,
-                readingHistory: readingHistory,
-                sortAscending: chapterSortAscending
-            )
-        } else {
-            MangaManager.shared.getNextChapter(
-                manga: manga,
-                chapters: chapters,
-                readingHistory: readingHistory,
-                sortAscending: chapterSortAscending
-            )
-        }
+        let chapter = MangaManager.shared.getNextChapter(
+            manga: manga,
+            chapters: chapters,
+            readingHistory: readingHistory,
+            sortAscending: chapterSortAscending
+        )
 
         if let chapter {
             return .chapter(chapter)

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -193,7 +193,7 @@ extension MangaView {
                 }
                 .store(in: &cancellables)
 
-            NotificationCenter.default.publisher(for: Notification.Name("Library.resumeLastOpenedChapter"))
+            NotificationCenter.default.publisher(for: .init("Library.resumeLastOpenedChapter"))
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
                     self?.updateReadButton()

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -788,7 +788,8 @@ extension MangaView.ViewModel {
             manga: manga,
             chapters: chapters,
             readingHistory: readingHistory,
-            sortAscending: chapterSortAscending
+            sortAscending: chapterSortAscending,
+            resumeLastOpenedChapter: UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
         )
 
         if let chapter {

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -193,13 +193,6 @@ extension MangaView {
                 }
                 .store(in: &cancellables)
 
-            NotificationCenter.default.publisher(for: Notification.Name("Library.resumeLastOpenedChapter"))
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] _ in
-                    self?.updateReadButton()
-                }
-                .store(in: &cancellables)
-
             // tracking
             NotificationCenter.default.publisher(for: .syncTrackItem)
                 .sink { [weak self] output in
@@ -821,11 +814,7 @@ extension MangaView.ViewModel {
             case .chapter(let nextChapter):
                 allChaptersRead = false
                 allChaptersLocked = false
-                if let history = readingHistory[nextChapter.id] {
-                    readingInProgress = history.date > 0 && history.page != -1
-                } else {
-                    readingInProgress = false
-                }
+                readingInProgress = readingHistory[nextChapter.id]?.date ?? 0 > 0
                 self.nextChapter = nextChapter
         }
     }

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -788,8 +788,7 @@ extension MangaView.ViewModel {
             manga: manga,
             chapters: chapters,
             readingHistory: readingHistory,
-            sortAscending: chapterSortAscending,
-            resumeLastOpenedChapter: UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
+            sortAscending: chapterSortAscending
         )
 
         if let chapter {

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -193,6 +193,13 @@ extension MangaView {
                 }
                 .store(in: &cancellables)
 
+            NotificationCenter.default.publisher(for: Notification.Name("Library.resumeLastOpenedChapter"))
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.updateReadButton()
+                }
+                .store(in: &cancellables)
+
             // tracking
             NotificationCenter.default.publisher(for: .syncTrackItem)
                 .sink { [weak self] output in
@@ -264,6 +271,10 @@ extension MangaView {
 }
 
 extension MangaView.ViewModel {
+    func refreshReadButtonState() {
+        updateReadButton()
+    }
+
     func markUpdatesViewed() async {
         if !UserDefaults.standard.bool(forKey: "General.incognitoMode") {
             await MangaUpdateManager.shared.viewAllUpdates(of: manga)
@@ -784,12 +795,27 @@ extension MangaView.ViewModel {
     private func getNextChapter() -> ChapterResult {
         guard !chapters.isEmpty else { return .none }
 
-        let chapter = MangaManager.shared.getNextChapter(
-            manga: manga,
-            chapters: chapters,
-            readingHistory: readingHistory,
-            sortAscending: chapterSortAscending
-        )
+        let resumeLastOpened = UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
+
+        let chapter = if resumeLastOpened {
+            MangaManager.shared.getLastOpenedChapter(
+                manga: manga,
+                chapters: chapters,
+                readingHistory: readingHistory
+            ) ?? MangaManager.shared.getNextChapter(
+                manga: manga,
+                chapters: chapters,
+                readingHistory: readingHistory,
+                sortAscending: chapterSortAscending
+            )
+        } else {
+            MangaManager.shared.getNextChapter(
+                manga: manga,
+                chapters: chapters,
+                readingHistory: readingHistory,
+                sortAscending: chapterSortAscending
+            )
+        }
 
         if let chapter {
             return .chapter(chapter)

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -193,6 +193,13 @@ extension MangaView {
                 }
                 .store(in: &cancellables)
 
+            NotificationCenter.default.publisher(for: Notification.Name("Library.resumeLastOpenedChapter"))
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.updateReadButton()
+                }
+                .store(in: &cancellables)
+
             // tracking
             NotificationCenter.default.publisher(for: .syncTrackItem)
                 .sink { [weak self] output in
@@ -814,7 +821,11 @@ extension MangaView.ViewModel {
             case .chapter(let nextChapter):
                 allChaptersRead = false
                 allChaptersLocked = false
-                readingInProgress = readingHistory[nextChapter.id]?.date ?? 0 > 0
+                if let history = readingHistory[nextChapter.id] {
+                    readingInProgress = history.date > 0 && history.page != -1
+                } else {
+                    readingInProgress = false
+                }
                 self.nextChapter = nextChapter
         }
     }

--- a/iOS/New/Views/Manga/MangaView.swift
+++ b/iOS/New/Views/Manga/MangaView.swift
@@ -197,6 +197,9 @@ struct MangaView: View {
                 await viewModel.syncTrackerProgress()
                 detailsLoaded = true
             }
+            .onAppear {
+                viewModel.refreshReadButtonState()
+            }
             .onChange(of: editMode) { mode in
                 guard let navigationController = path.rootViewController?.navigationController
                 else { return }

--- a/iOS/New/Views/Settings/Settings.swift
+++ b/iOS/New/Views/Settings/Settings.swift
@@ -182,6 +182,11 @@ extension Settings {
                 value: .toggle(.init())
             ),
             .init(
+                key: "Library.resumeLastOpenedChapter",
+                title: NSLocalizedString("RESUME_LAST_OPENED_CHAPTER"),
+                value: .toggle(.init())
+            ),
+            .init(
                 key: "Library.unreadChapterBadges",
                 title: NSLocalizedString("UNREAD_CHAPTER_BADGES"),
                 value: .toggle(.init())

--- a/iOS/New/Views/Settings/Settings.swift
+++ b/iOS/New/Views/Settings/Settings.swift
@@ -182,11 +182,6 @@ extension Settings {
                 value: .toggle(.init())
             ),
             .init(
-                key: "Library.resumeLastOpenedChapter",
-                title: NSLocalizedString("RESUME_LAST_OPENED_CHAPTER"),
-                value: .toggle(.init())
-            ),
-            .init(
                 key: "Library.unreadChapterBadges",
                 title: NSLocalizedString("UNREAD_CHAPTER_BADGES"),
                 value: .toggle(.init())

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1312,7 +1312,8 @@ extension LibraryViewController {
                     manga: manga,
                     chapters: sortedChapters,
                     readingHistory: history,
-                    sortAscending: sortAscending
+                    sortAscending: sortAscending,
+                    resumeLastOpenedChapter: UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
                 )
 
                 if let chapter = nextChapter {

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1312,8 +1312,7 @@ extension LibraryViewController {
                     manga: manga,
                     chapters: sortedChapters,
                     readingHistory: history,
-                    sortAscending: sortAscending,
-                    resumeLastOpenedChapter: UserDefaults.standard.bool(forKey: "Library.resumeLastOpenedChapter")
+                    sortAscending: sortAscending
                 )
 
                 if let chapter = nextChapter {


### PR DESCRIPTION
Start Reading currently ignores the last chapter you actually opened if that chapter is already marked as read, which can make it jump to the wrong place after skipping around.

This changes it to prefer the most recently opened chapter from reading history first, and only fall back to the first unread chapter if there’s no history yet.
