### PR TITLE
fix: address text reader issues

### DIFF
--- a/iOS/Extensions/HostingController.swift
+++ b/iOS/Extensions/HostingController.swift
@@ -8,9 +8,15 @@
 import SwiftUI
 
 final class HostingController<Content: View>: UIHostingController<Content> {
+    /// When true, skips `invalidateIntrinsicContentSize` during layout.
+    /// Used by the scroll text reader to prevent size recalculation during bar transitions.
+    var suppressInvalidation = false
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        self.view.invalidateIntrinsicContentSize()
+        if !suppressInvalidation {
+            self.view.invalidateIntrinsicContentSize()
+        }
     }
 }
 

--- a/iOS/UI/Reader/ReaderViewController.swift
+++ b/iOS/UI/Reader/ReaderViewController.swift
@@ -247,9 +247,15 @@ class ReaderViewController: BaseObservingViewController {
             guard let self else { return }
             // Only switch if we're currently in a text reader
             if self.reader is ReaderTextViewController || self.reader is ReaderPagedTextViewController {
-                self.setReader(.text)
-                self.reader?.setChapter(self.chapter, startPage: self.currentPage)
-                self.updateTapZone()
+                // Save current position before switching so the new reader can restore it
+                Task {
+                    await self.updateReadPosition()
+                    await MainActor.run {
+                        self.setReader(.text)
+                        self.reader?.setChapter(self.chapter, startPage: self.currentPage)
+                        self.updateTapZone()
+                    }
+                }
             }
         }
         addObserver(forName: UIScene.willDeactivateNotification) { [weak self] _ in

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -392,7 +392,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         }
 
         // Update current page display (1-indexed for UI)
-        delegate?.setCurrentPage(targetIndex + 1, position: nil)
+        delegate?.setCurrentPage(targetIndex + 1, position: normalizedPosition(for: targetIndex))
         updateSliderPosition()
     }
 
@@ -417,6 +417,14 @@ class ReaderPagedTextViewController: BaseObservingViewController {
             // Single page - pass parent reference so it can get live safe area updates
             return TextSinglePageViewController(page: pages[index], parentReader: self)
         }
+    }
+
+    /// Compute a normalized 0-1 position from the current page index.
+    /// Both the scroll and paged text readers use this format so switching
+    /// between them preserves the reading position.
+    private func normalizedPosition(for pageIndex: Int) -> Double {
+        guard pages.count > 1 else { return 0 }
+        return Double(pageIndex) / Double(pages.count - 1)
     }
 
     private func updateSliderPosition() {
@@ -483,8 +491,7 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
         if targetIndex >= 0 && targetIndex < pages.count {
             move(toPage: targetIndex, animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"))
         } else if targetIndex < 0 {
-            // Load previous chapter
-            loadPreviousChapter()
+            navigateToPreviousChapterTransition()
         }
     }
 
@@ -500,8 +507,7 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
         if targetIndex >= 0 && targetIndex < pages.count {
             move(toPage: targetIndex, animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"))
         } else if targetIndex >= pages.count {
-            // Load next chapter
-            loadNextChapter()
+            navigateToNextChapterTransition()
         }
     }
 
@@ -548,6 +554,66 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
         Task {
             await loadChapter(chapter, startPage: startPage)
         }
+    }
+
+    /// Navigate toward the previous chapter transition page.
+    /// First call shows the transition info page; second call (when already on it) triggers the chapter load.
+    private func navigateToPreviousChapterTransition() {
+        guard let currentVC = pageViewController.viewControllers?.first else { return }
+        let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
+
+        // Already on the transition page — trigger the chapter load
+        if let transitionVC = currentVC as? ChapterTransitionViewController {
+            guard transitionVC.chapter != nil else { return }
+            transitionVC.performTransition()
+            return
+        }
+
+        // Show the transition page
+        let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
+        let transitionVC = ChapterTransitionViewController(
+            direction: .previous,
+            chapter: previousChapter,
+            currentChapter: chapter,
+            sourceId: sourceId,
+            mangaId: viewModel.manga.key,
+            parentReader: self
+        )
+        pageViewController.setViewControllers(
+            [transitionVC],
+            direction: .reverse,
+            animated: animated
+        )
+    }
+
+    /// Navigate toward the next chapter transition page.
+    /// First call shows the transition info page; second call (when already on it) triggers the chapter load.
+    private func navigateToNextChapterTransition() {
+        guard let currentVC = pageViewController.viewControllers?.first else { return }
+        let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
+
+        // Already on the transition page — trigger the chapter load
+        if let transitionVC = currentVC as? ChapterTransitionViewController {
+            guard transitionVC.chapter != nil else { return }
+            transitionVC.performTransition()
+            return
+        }
+
+        // Show the transition page
+        let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
+        let transitionVC = ChapterTransitionViewController(
+            direction: .next,
+            chapter: nextChapter,
+            currentChapter: chapter,
+            sourceId: sourceId,
+            mangaId: viewModel.manga.key,
+            parentReader: self
+        )
+        pageViewController.setViewControllers(
+            [transitionVC],
+            direction: .forward,
+            animated: animated
+        )
     }
 
     func loadPreviousChapter() {
@@ -625,7 +691,7 @@ extension ReaderPagedTextViewController: UIPageViewControllerDelegate {
             currentCharacterOffset = doublePage.leftPage.range.location
         }
 
-        delegate?.setCurrentPage(currentPageIndex + 1, position: nil)
+        delegate?.setCurrentPage(currentPageIndex + 1, position: normalizedPosition(for: currentPageIndex))
         updateSliderPosition()
     }
 

--- a/iOS/UI/Reader/Readers/Text/Paged/TextDoublePageViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/TextDoublePageViewController.swift
@@ -96,6 +96,8 @@ class TextDoublePageViewController: UIViewController {
         let tv = UITextView()
         tv.isEditable = false
         tv.isScrollEnabled = false
+        tv.isUserInteractionEnabled = false  // Let taps pass through to parent tap zones
+        tv.textContainer.lineFragmentPadding = 0  // Match paginator's layout width
         tv.backgroundColor = .systemBackground
         return tv
     }

--- a/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
@@ -430,7 +430,16 @@ class TextPaginator {
         )
 
         if sentenceBreak.location != NSNotFound {
-            let breakEnd = min(sentenceBreak.location + 2, text.length)
+            // Include the sentence ender. Also include the following character
+            // only if it's whitespace so we never split a word across pages.
+            var breakEnd = sentenceBreak.location + 1
+            if breakEnd < text.length {
+                let nextChar = text.character(at: breakEnd)
+                if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(nextChar)!) {
+                    breakEnd += 1
+                }
+            }
+            breakEnd = min(breakEnd, text.length)
             return NSRange(location: proposedRange.location, length: breakEnd - proposedRange.location)
         }
 

--- a/iOS/UI/Reader/Readers/Text/Paged/TextSinglePageViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/TextSinglePageViewController.swift
@@ -13,6 +13,7 @@ class TextSinglePageViewController: UIViewController {
         let tv = UITextView()
         tv.isEditable = false
         tv.isScrollEnabled = false
+        tv.isUserInteractionEnabled = false  // Let taps pass through to parent tap zones
         tv.backgroundColor = .systemBackground
         tv.font = .systemFont(ofSize: 18)
         return tv
@@ -44,6 +45,11 @@ class TextSinglePageViewController: UIViewController {
             textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+
+        // Match the paginator's lineFragmentPadding = 0 so the text layout
+        // width is identical. The default (5pt) causes lines to wrap earlier
+        // than the paginator predicted, pushing words off the visible area.
+        textView.textContainer.lineFragmentPadding = 0
 
         // Set the text content
         if page.attributedContent.length > 0 {

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
@@ -302,6 +302,12 @@ class ReaderTextViewController: BaseViewController {
         super.viewSafeAreaInsetsDidChange()
         let newInsets = view.safeAreaInsets
         defer { lastSafeAreaInsets = newInsets }
+
+        // Keep content inset in sync so the scroll view allows scrolling
+        // past the content top (text starts below the navigation bar).
+        scrollView.contentInset = UIEdgeInsets(top: newInsets.top, left: 0, bottom: newInsets.bottom, right: 0)
+        scrollView.verticalScrollIndicatorInsets = scrollView.contentInset
+
         guard let lastInsets = lastSafeAreaInsets else { return }
         let topDelta = newInsets.top - lastInsets.top
         guard topDelta != 0 else { return }
@@ -494,6 +500,7 @@ extension ReaderTextViewController {
             needsPageCountUpdate = true
 
             let prevHeight = showsPreviousTransition ? transitionPageHeight : 0
+            let safeTop = scrollView.contentInset.top
 
             if restorePosition {
                 pendingScrollRestore = true
@@ -503,9 +510,15 @@ extension ReaderTextViewController {
                         self.updateEstimatedPageCount()
                         let sectionHeight = self.sectionContentHeight(at: 0)
                         let screenHeight = self.scrollView.frame.size.height
+                        let insetTop = self.scrollView.contentInset.top
                         if sectionHeight > 0, screenHeight > 0 {
-                            let targetOffset = prevHeight + (sectionHeight - screenHeight) * savedProgress
-                            self.scrollView.setContentOffset(CGPoint(x: 0, y: max(prevHeight, targetOffset)), animated: false)
+                            let scrollStart = prevHeight - insetTop
+                            let scrollableRange = sectionHeight - screenHeight + insetTop
+                            let targetOffset = scrollStart + scrollableRange * savedProgress
+                            self.scrollView.setContentOffset(
+                                CGPoint(x: 0, y: max(prevHeight - insetTop, targetOffset)),
+                                animated: false
+                            )
                             let currentPage = min(self.estimatedPageCount, Int(savedProgress * CGFloat(self.estimatedPageCount)) + 1)
                             self.lastReportedPage = currentPage
                             self.delegate?.setCurrentPage(currentPage, position: savedProgress)
@@ -514,7 +527,7 @@ extension ReaderTextViewController {
                     self.pendingScrollRestore = false
                 }
             } else {
-                scrollView.setContentOffset(.init(x: 0, y: prevHeight), animated: false)
+                scrollView.setContentOffset(.init(x: 0, y: prevHeight - safeTop), animated: false)
             }
 
             isLoadingChapter = false

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
@@ -41,6 +41,7 @@ class ReaderTextViewController: BaseViewController {
     private var loadingNext = false
     private var loadingPrevious = false
     private var hasReachedEnd = false
+    private var lastSafeAreaInsets: UIEdgeInsets = .zero
 
     private var isSliding = false
     private var estimatedPageCount = 1
@@ -286,8 +287,27 @@ class ReaderTextViewController: BaseViewController {
 
     // MARK: - Layout
 
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        // Compensate contentOffset when bars show/hide so visible text doesn't shift.
+        // contentInsetAdjustmentBehavior is .never, so we handle the delta manually.
+        let newInsets = view.safeAreaInsets
+        let topDelta = newInsets.top - lastSafeAreaInsets.top
+        lastSafeAreaInsets = newInsets
+        if topDelta != 0 {
+            var offset = scrollView.contentOffset
+            offset.y += topDelta
+            scrollView.contentOffset = offset
+        }
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
+        // Capture initial safe area insets once the view is laid out
+        if lastSafeAreaInsets == .zero {
+            lastSafeAreaInsets = view.safeAreaInsets
+        }
 
         for hc in allHostingControllers {
             hc.view.invalidateIntrinsicContentSize()
@@ -665,8 +685,15 @@ extension ReaderTextViewController: ReaderReaderDelegate {
         let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
         let prevHeight = showsPreviousTransition ? transitionPageHeight : 0
 
+        // Already scrolled into the previous transition area
         if scrollView.contentOffset.y <= prevHeight {
-            scrollView.setContentOffset(.init(x: 0, y: 0), animated: animated)
+            if scrollView.contentOffset.y <= 0 {
+                // Fully at top — trigger chapter load on second press
+                checkInfiniteLoad()
+            } else {
+                // Scroll to show the full transition view
+                scrollView.setContentOffset(.init(x: 0, y: 0), animated: animated)
+            }
             return
         }
 
@@ -677,6 +704,23 @@ extension ReaderTextViewController: ReaderReaderDelegate {
     func moveRight() {
         let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
         let maxOffset = scrollView.contentSize.height - scrollView.bounds.height
+
+        // Check if we're already in the next transition area
+        if showsNextTransition {
+            // Calculate where the last section's content ends
+            let lastSectionEnd: CGFloat
+            if let lastIndex = sections.indices.last {
+                lastSectionEnd = sectionContentStartY(at: lastIndex) + sectionContentHeight(at: lastIndex)
+            } else {
+                lastSectionEnd = 0
+            }
+            let transitionStart = lastSectionEnd
+            if scrollView.contentOffset.y + scrollView.bounds.height >= transitionStart {
+                // Already seeing the transition — trigger chapter load
+                checkInfiniteLoad()
+                return
+            }
+        }
 
         let target = min(maxOffset, scrollView.contentOffset.y + scrollView.bounds.height * 2 / 3)
         scrollView.setContentOffset(.init(x: 0, y: target), animated: animated)

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
@@ -41,7 +41,6 @@ class ReaderTextViewController: BaseViewController {
     private var loadingNext = false
     private var loadingPrevious = false
     private var hasReachedEnd = false
-    private var lastSafeAreaInsets: UIEdgeInsets = .zero
 
     private var isSliding = false
     private var estimatedPageCount = 1
@@ -49,6 +48,13 @@ class ReaderTextViewController: BaseViewController {
     private var isReportingProgress = false
     private var lastReportedPage = 0
     private var needsPageCountUpdate = false
+
+    /// Tracks the last known safe area insets so we can compensate content offset
+    /// when bars show/hide with `contentInsetAdjustmentBehavior = .never`.
+    private var lastSafeAreaInsets: UIEdgeInsets?
+    /// When true, suppresses hosting controller size invalidation to prevent
+    /// layout passes from undoing offset compensation during bar transitions.
+    private var isSafeAreaTransitioning = false
 
     // MARK: - Scroll Position Persistence
 
@@ -114,6 +120,9 @@ class ReaderTextViewController: BaseViewController {
         if #available(iOS 16.0, *) {
             hc.sizingOptions = .intrinsicContentSize
         }
+        if #available(iOS 16.4, *) {
+            hc.safeAreaRegions = []
+        }
         hc.view.backgroundColor = .clear
         return hc
     }
@@ -128,7 +137,9 @@ class ReaderTextViewController: BaseViewController {
     private var showsNextTransition = false
 
     private var transitionPageHeight: CGFloat {
-        scrollView.frame.height
+        // Use the full view height so transition pages stay a stable size
+        // regardless of bar visibility (scrollView.frame changes with safe area).
+        view.bounds.height
     }
 
     init(source: AidokuRunner.Source?, manga: AidokuRunner.Manga) {
@@ -289,46 +300,63 @@ class ReaderTextViewController: BaseViewController {
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        // Compensate contentOffset when bars show/hide so visible text doesn't shift.
-        // contentInsetAdjustmentBehavior is .never, so we handle the delta manually.
         let newInsets = view.safeAreaInsets
-        let topDelta = newInsets.top - lastSafeAreaInsets.top
-        lastSafeAreaInsets = newInsets
-        if topDelta != 0 {
-            var offset = scrollView.contentOffset
-            offset.y += topDelta
-            scrollView.contentOffset = offset
+        defer { lastSafeAreaInsets = newInsets }
+        guard let lastInsets = lastSafeAreaInsets else { return }
+        let topDelta = newInsets.top - lastInsets.top
+        guard topDelta != 0 else { return }
+
+        // On iOS 16.4+, safeAreaRegions = [] on the hosting controllers prevents
+        // them from resizing when bars show/hide — no compensation needed.
+        // On older iOS, suppress invalidation and compensate the offset manually.
+        if #unavailable(iOS 16.4) {
+            isSafeAreaTransitioning = true
+            setHostingControllerInvalidation(suppressed: true)
+            scrollView.contentOffset.y += topDelta
+        }
+    }
+
+    private func setHostingControllerInvalidation(suppressed: Bool) {
+        for hc in allHostingControllers {
+            (hc as? HostingController<ReaderTextView>)?.suppressInvalidation = suppressed
         }
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        // Capture initial safe area insets once the view is laid out
-        if lastSafeAreaInsets == .zero {
-            lastSafeAreaInsets = view.safeAreaInsets
+        // During bar show/hide on iOS < 16.4, skip layout updates to prevent
+        // content shifting, then clear the suppression flags for the next pass.
+        if isSafeAreaTransitioning {
+            isSafeAreaTransitioning = false
+            setHostingControllerInvalidation(suppressed: false)
+            return
         }
 
         for hc in allHostingControllers {
             hc.view.invalidateIntrinsicContentSize()
         }
 
-        let screenHeight = scrollView.frame.height
+        let transHeight = transitionPageHeight
         if showsPreviousTransition {
-            prevHeightConstraint?.constant = screenHeight
+            prevHeightConstraint?.constant = transHeight
         }
         if showsNextTransition {
-            nextHeightConstraint?.constant = screenHeight
+            nextHeightConstraint?.constant = transHeight
         }
         // Keep inline transition views in sync
         for section in sections where section.transitionView != nil {
-            section.transitionHeightConstraint?.constant = screenHeight
+            section.transitionHeightConstraint?.constant = transHeight
         }
 
         if needsPageCountUpdate {
             updateEstimatedPageCount()
         }
     }
+}
+
+// MARK: - Section Helpers & Chapter Loading
+extension ReaderTextViewController {
 
     /// Recalculate estimated page count for the current chapter's section.
     private func updateEstimatedPageCount() {
@@ -356,7 +384,7 @@ class ReaderTextViewController: BaseViewController {
     // MARK: - Boundary Transition Views
 
     private func updateBoundaryTransitionViews() {
-        let screenHeight = scrollView.frame.height > 0 ? scrollView.frame.height : view.bounds.height
+        let screenHeight = transitionPageHeight
 
         // Previous transition (top) — shows info about the chapter before sections[0]
         if let prevView = previousTransitionView, let firstSection = sections.first {
@@ -530,7 +558,7 @@ class ReaderTextViewController: BaseViewController {
             await MainActor.run {
                 // Add an inline transition view after the last section
                 let lastSection = sections.last!
-                let screenHeight = scrollView.frame.height > 0 ? scrollView.frame.height : view.bounds.height
+                let screenHeight = transitionPageHeight
                 let tv = createInlineTransitionView(
                     finishedChapter: lastSection.chapter,
                     nextChapter: nextCh
@@ -596,7 +624,7 @@ class ReaderTextViewController: BaseViewController {
             }
 
             await MainActor.run {
-                let screenHeight = scrollView.frame.height > 0 ? scrollView.frame.height : view.bounds.height
+                let screenHeight = transitionPageHeight
                 let oldContentHeight = scrollView.contentSize.height
                 let oldOffset = scrollView.contentOffset.y
 


### PR DESCRIPTION
- Fix word truncation by matching lineFragmentPadding between paginator and UITextView
- Fix content shifting in scroll reader when bars toggle via safe area compensation
- Enable tap zones by disabling UITextView user interaction on read-only pages
- Add two-step keyboard navigation at chapter boundaries (transition page first)
- Preserve read position when switching between paged and scroll reader styles
- Fix sentence break edge case that could split words across pages
