### PR TITLE
feat: sort available sources when migrating manga

### DIFF
--- a/iOS/UI/Migration/MigrateSourceSelectionView.swift
+++ b/iOS/UI/Migration/MigrateSourceSelectionView.swift
@@ -12,7 +12,9 @@ struct MigrateSourceSelectionView: View {
     var excludedSources: [String] = []
 
     @Binding var selectedSources: [SourceInfo2]
-    @State var availableSources = SourceManager.shared.sources.map { $0.toInfo() }
+    @State var availableSources = SourceManager.shared.sources
+        .map { $0.toInfo() }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
 
     @State private var editMode: EditMode = .active
 


### PR DESCRIPTION
Sorts available sources when migrating manga to a new source

<img width="603" height="1311" alt="Screenshot 2026-03-31 at 9 21 56 PM" src="https://github.com/user-attachments/assets/42de4d3d-086a-4186-955f-68db6e7be034" />
