### PR TITLE
feat: tracker chapter number offset

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 		FB077DAD2E7DC85800C9C214 /* BackupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupsView.swift; sourceTree = "<group>"; };
 		FB077DAF2E7DCFF700C9C214 /* String+Highlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Highlight.swift"; sourceTree = "<group>"; };
 		FB0AB8922F50B81800AF1451 /* 0.8.2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 0.8.2.xcdatamodel; sourceTree = "<group>"; };
+		FB0AB8B42F55D00100AF1451 /* 0.8.3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 0.8.3.xcdatamodel; sourceTree = "<group>"; };
 		FB0AB8932F50B98000AF1451 /* BackupCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupCategory.swift; sourceTree = "<group>"; };
 		FB0AB8A22F51FD8D00AF1451 /* FilterGroupCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroupCreateView.swift; sourceTree = "<group>"; };
 		FB0AB8A42F52046F00AF1451 /* FilterGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterGroup.swift; sourceTree = "<group>"; };
@@ -3720,6 +3721,7 @@
 		FB1B482B277CE18D0056D02C /* Aidoku.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				FB0AB8B42F55D00100AF1451 /* 0.8.3.xcdatamodel */,
 				FB0AB8922F50B81800AF1451 /* 0.8.2.xcdatamodel */,
 				FB947CF92EF1CC4D00FC6226 /* 0.8.xcdatamodel */,
 				FB63D4FF2E37CBEF004FF4DC /* 0.7.1.xcdatamodel */,
@@ -3731,7 +3733,7 @@
 				FBCA1B2228889F1D007149C5 /* 0.5.xcdatamodel */,
 				FB1B482C277CE18D0056D02C /* Shared.xcdatamodel */,
 			);
-			currentVersion = FB0AB8922F50B81800AF1451 /* 0.8.2.xcdatamodel */;
+			currentVersion = FB0AB8B42F55D00100AF1451 /* 0.8.3.xcdatamodel */;
 			path = Aidoku.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/AidokuTests/TrackerSyncTests.swift
+++ b/AidokuTests/TrackerSyncTests.swift
@@ -164,4 +164,19 @@ actor TestableTracker: Tracker {
         // all matching chapters should be returned even if there's only one unread
         #expect(result.count == 5)
     }
+
+    @Test func testApplyChapterOffset() {
+        let value = TrackerManager.applyChapterOffset(to: 9, offset: 2, maxChapters: nil)
+        #expect(value == 11)
+    }
+
+    @Test func testApplyChapterOffsetNegative() {
+        let value = TrackerManager.applyChapterOffset(to: 4, offset: -10, maxChapters: nil)
+        #expect(value == 0)
+    }
+
+    @Test func testApplyChapterOffsetMaxClamp() {
+        let value = TrackerManager.applyChapterOffset(to: 9, offset: 5, maxChapters: 10)
+        #expect(value == 10)
+    }
 }

--- a/Shared/Aidoku.xcdatamodeld/.xccurrentversion
+++ b/Shared/Aidoku.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>0.8.2.xcdatamodel</string>
+	<string>0.8.3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Shared/Aidoku.xcdatamodeld/0.8.3.xcdatamodel/contents
+++ b/Shared/Aidoku.xcdatamodeld/0.8.3.xcdatamodel/contents
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25D125" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Category" representedClassName="CategoryObject" syncable="YES" codeGenerationType="class">
+        <attribute name="data" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
+        <attribute name="group" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="sort" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <relationship name="libraryObjects" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="LibraryManga" inverseName="categories" inverseEntity="LibraryManga"/>
+    </entity>
+    <entity name="Chapter" representedClassName="ChapterObject" syncable="YES">
+        <attribute name="chapter" optional="YES" attributeType="Float" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="dateUploaded" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="lang" attributeType="String" defaultValueString="en"/>
+        <attribute name="locked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="mangaId" attributeType="String" defaultValueString=""/>
+        <attribute name="scanlator" optional="YES" attributeType="String"/>
+        <attribute name="sourceId" attributeType="String" defaultValueString=""/>
+        <attribute name="sourceOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thumbnail" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="volume" optional="YES" attributeType="Float" defaultValueString="-1" usesScalarValueType="YES"/>
+        <relationship name="fileInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocalFileInfo" inverseName="chapter" inverseEntity="LocalFileInfo"/>
+        <relationship name="history" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="History" inverseName="chapter" inverseEntity="History"/>
+        <relationship name="manga" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Manga" inverseName="chapters" inverseEntity="Manga"/>
+        <relationship name="mangaUpdate" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="MangaUpdate" inverseName="chapter" inverseEntity="MangaUpdate"/>
+    </entity>
+    <entity name="History" representedClassName="HistoryObject" syncable="YES">
+        <attribute name="chapterId" attributeType="String" defaultValueString=""/>
+        <attribute name="completed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="dateRead" attributeType="Date" defaultDateTimeInterval="665122680" usesScalarValueType="NO"/>
+        <attribute name="mangaId" attributeType="String" defaultValueString=""/>
+        <attribute name="progress" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="scrollPosition" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="sourceId" attributeType="String" defaultValueString=""/>
+        <attribute name="total" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="chapter" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chapter" inverseName="history" inverseEntity="Chapter"/>
+        <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReadingSession" inverseName="history" inverseEntity="ReadingSession"/>
+    </entity>
+    <entity name="LibraryManga" representedClassName="LibraryMangaObject" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <attribute name="lastChapter" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastOpened" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <attribute name="lastRead" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastUpdated" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <attribute name="lastUpdatedChapters" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="libraryObjects" inverseEntity="Category"/>
+        <relationship name="manga" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Manga" inverseName="libraryObject" inverseEntity="Manga"/>
+    </entity>
+    <entity name="LocalFileInfo" representedClassName="LocalFileInfoObject" syncable="YES" codeGenerationType="class">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="path" attributeType="String" defaultValueString=""/>
+        <relationship name="chapter" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chapter" inverseName="fileInfo" inverseEntity="Chapter"/>
+        <relationship name="manga" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Manga" inverseName="fileInfo" inverseEntity="Manga"/>
+    </entity>
+    <entity name="Manga" representedClassName="MangaObject" syncable="YES">
+        <attribute name="artist" optional="YES" attributeType="String"/>
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="chapterCount" optional="YES" attributeType="Integer 64" derived="YES" derivationExpression="chapters.@count" usesScalarValueType="YES"/>
+        <attribute name="chapterFlags" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="cover" optional="YES" attributeType="String"/>
+        <attribute name="desc" optional="YES" attributeType="String"/>
+        <attribute name="editedKeys" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="langFilter" optional="YES" attributeType="String"/>
+        <attribute name="neverUpdate" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="nextUpdateTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="nsfw" attributeType="Integer 16" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="scanlatorFilter" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="sourceId" attributeType="String" defaultValueString=""/>
+        <attribute name="status" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="viewer" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="chapters" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Chapter" inverseName="manga" inverseEntity="Chapter"/>
+        <relationship name="fileInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocalFileInfo" inverseName="manga" inverseEntity="LocalFileInfo"/>
+        <relationship name="libraryObject" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="LibraryManga" inverseName="manga" inverseEntity="LibraryManga"/>
+        <fetchedProperty name="unreadChapters" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="Chapter" predicateString="$FETCH_SOURCE.sourceId == sourceId AND $FETCH_SOURCE.id == mangaId AND (history == nil OR history.completed == false)"/>
+        </fetchedProperty>
+    </entity>
+    <entity name="MangaUpdate" representedClassName="MangaUpdateObject" syncable="YES" codeGenerationType="class">
+        <attribute name="chapterId" optional="YES" attributeType="String"/>
+        <attribute name="date" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <attribute name="mangaId" attributeType="String" defaultValueString=""/>
+        <attribute name="sourceId" attributeType="String" defaultValueString=""/>
+        <attribute name="viewed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="chapter" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chapter" inverseName="mangaUpdate" inverseEntity="Chapter"/>
+    </entity>
+    <entity name="ReadingSession" representedClassName="ReadingSessionObject" syncable="YES" codeGenerationType="class">
+        <attribute name="endDate" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <attribute name="pagesRead" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="startDate" attributeType="Date" defaultDateTimeInterval="-978285600" usesScalarValueType="NO"/>
+        <relationship name="history" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="History" inverseName="sessions" inverseEntity="History"/>
+    </entity>
+    <entity name="Source" representedClassName="SourceObject" syncable="YES" codeGenerationType="class">
+        <attribute name="apiVersion" attributeType="String" defaultValueString="0.6"/>
+        <attribute name="customSource" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="listing" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="path" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Track" representedClassName="TrackObject" syncable="YES" codeGenerationType="class">
+        <attribute name="chapterOffset" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="String" defaultValueString=""/>
+        <attribute name="mangaId" attributeType="String" defaultValueString=""/>
+        <attribute name="sourceId" attributeType="String" defaultValueString=""/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="trackerId" attributeType="String" defaultValueString=""/>
+    </entity>
+    <configuration name="Cloud" usedWithCloudKit="YES">
+        <memberEntity name="Category"/>
+        <memberEntity name="Chapter"/>
+        <memberEntity name="History"/>
+        <memberEntity name="LibraryManga"/>
+        <memberEntity name="Manga"/>
+        <memberEntity name="Track"/>
+        <memberEntity name="MangaUpdate"/>
+        <memberEntity name="LocalFileInfo"/>
+        <memberEntity name="ReadingSession"/>
+    </configuration>
+    <configuration name="Local">
+        <memberEntity name="Source"/>
+    </configuration>
+</model>

--- a/Shared/Data/Backup/Models/BackupTrackItem.swift
+++ b/Shared/Data/Backup/Models/BackupTrackItem.swift
@@ -13,6 +13,7 @@ struct BackupTrackItem: Codable, Hashable {
     var mangaId: String
     var sourceId: String
     var title: String?
+    var chapterOffset: Int?
 
     init(trackObject: TrackObject) {
         id = trackObject.id ?? ""
@@ -20,6 +21,7 @@ struct BackupTrackItem: Codable, Hashable {
         mangaId = trackObject.mangaId ?? ""
         sourceId = trackObject.sourceId ?? ""
         title = trackObject.title
+        chapterOffset = Int(trackObject.chapterOffset)
     }
 
     func toObject(context: NSManagedObjectContext? = nil) -> TrackObject {
@@ -34,6 +36,7 @@ struct BackupTrackItem: Codable, Hashable {
         obj.mangaId = mangaId
         obj.sourceId = sourceId
         obj.title = title
+        obj.chapterOffset = Int16(chapterOffset ?? 0)
         return obj
     }
 }

--- a/Shared/Data/Database/Objects/TrackObject.swift
+++ b/Shared/Data/Database/Objects/TrackObject.swift
@@ -9,6 +9,13 @@ import Foundation
 
 extension TrackObject {
     func toItem() -> TrackItem {
-        TrackItem(id: id ?? "", trackerId: trackerId ?? "", sourceId: sourceId ?? "", mangaId: mangaId ?? "", title: title)
+        return TrackItem(
+            id: id ?? "",
+            trackerId: trackerId ?? "",
+            sourceId: sourceId ?? "",
+            mangaId: mangaId ?? "",
+            title: title,
+            chapterOffset: Int(chapterOffset)
+        )
     }
 }

--- a/Shared/Data/Database/Objects/TrackObject.swift
+++ b/Shared/Data/Database/Objects/TrackObject.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension TrackObject {
     func toItem() -> TrackItem {
-        return TrackItem(
+       TrackItem(
             id: id ?? "",
             trackerId: trackerId ?? "",
             sourceId: sourceId ?? "",

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -648,6 +648,8 @@
 "STARTED" = "Started";
 "FINISHED" = "Finished";
 "STOP_TRACKING" = "Stop Tracking";
+"SET_TRACK_CHAPTER_OFFSET" = "Set Chapter Offset";
+"TRACK_CHAPTER_OFFSET_TEXT" = "Adjust automatic tracker chapter updates for this title when source chapter numbers differ from tracker chapter numbers.";
 "TITLE_DISPLAY_MODE" = "Title Display Mode";
 "NOT_PUBLISHED" = "Not Published";
 "MANGA" = "Manga";

--- a/Shared/Localization/pt.lproj/Localizable.strings
+++ b/Shared/Localization/pt.lproj/Localizable.strings
@@ -257,6 +257,8 @@
 "TRACK_PLANNING" = "Planejamento";
 "TRACK_DROPPED" = "Abandonado";
 "STOP_TRACKING" = "Deixar de Seguir";
+"SET_TRACK_CHAPTER_OFFSET" = "Definir Compensação de Capítulo";
+"TRACK_CHAPTER_OFFSET_TEXT" = "Ajusta automaticamente as atualizações de capítulo no rastreador para este título quando a numeração dos capítulos na fonte difere da numeração no rastreador.";
 "ONESHOT" = "One-shot";
 "NOT_PUBLISHED" = "Não Publicado";
 "MANGA" = "Manga";

--- a/Shared/Managers/CoreData/CoreDataManager+Track.swift
+++ b/Shared/Managers/CoreData/CoreDataManager+Track.swift
@@ -85,6 +85,7 @@ extension CoreDataManager {
         sourceId: String,
         mangaId: String,
         title: String?,
+        chapterOffset: Int = 0,
         context: NSManagedObjectContext? = nil
     ) -> TrackObject {
         let context = context ?? self.context
@@ -94,7 +95,24 @@ extension CoreDataManager {
         object.sourceId = sourceId
         object.mangaId = mangaId
         object.title = title
+        object.chapterOffset = Int16(chapterOffset)
         return object
+    }
+
+    func setTrackChapterOffset(
+        trackerId: String,
+        sourceId: String,
+        mangaId: String,
+        chapterOffset: Int,
+        context: NSManagedObjectContext? = nil
+    ) {
+        guard let object = getTrack(
+            trackerId: trackerId,
+            sourceId: sourceId,
+            mangaId: mangaId,
+            context: context
+        ) else { return }
+        object.chapterOffset = Int16(chapterOffset)
     }
 
     /// Removes a track item.

--- a/Shared/Tracking/Models/TrackItem.swift
+++ b/Shared/Tracking/Models/TrackItem.swift
@@ -21,4 +21,6 @@ struct TrackItem: Sendable {
     var title: String?
     /// The paired tracking state of the item.
     var state: TrackState?
+    /// The chapter offset to apply for automatic tracker updates.
+    var chapterOffset: Int
 }

--- a/Shared/Tracking/TrackerManager.swift
+++ b/Shared/Tracking/TrackerManager.swift
@@ -107,12 +107,20 @@ actor TrackerManager {
             if displayMode == .chapter {
                 // chapter mode: only update chapter, don't update volume
                 if let chapterNum, chapterNum > 0 && state.lastReadChapter ?? 0 < chapterNum {
-                    update.lastReadChapter = chapterNum
+                    update.lastReadChapter = applyChapterOffset(
+                        to: chapterNum,
+                        offset: item.chapterOffset,
+                        maxChapters: state.totalChapters
+                    )
                 } else if let volumeNum {
                     // no chapter metadata, use volume number as chapter
                     let chapterFromVolume = Float(volumeNum)
                     if chapterFromVolume > state.lastReadChapter ?? 0 {
-                        update.lastReadChapter = chapterFromVolume
+                        update.lastReadChapter = applyChapterOffset(
+                            to: chapterFromVolume,
+                            offset: item.chapterOffset,
+                            maxChapters: state.totalChapters
+                        )
                     }
                 }
             } else if displayMode == .volume {
@@ -129,7 +137,11 @@ actor TrackerManager {
             } else {
                 // default mode: update both chapter and volume if available
                 if let chapterNum, chapterNum > 0 && state.lastReadChapter ?? 0 < chapterNum {
-                    update.lastReadChapter = chapterNum
+                    update.lastReadChapter = applyChapterOffset(
+                        to: chapterNum,
+                        offset: item.chapterOffset,
+                        maxChapters: state.totalChapters
+                    )
                 }
                 if let volumeNum, volumeNum > 0 && state.lastReadVolume ?? 0 < volumeNum {
                     update.lastReadVolume = volumeNum
@@ -230,7 +242,8 @@ actor TrackerManager {
                 trackerId: tracker.id,
                 sourceId: manga.sourceKey,
                 mangaId: manga.key,
-                title: item.title ?? manga.title
+                title: item.title ?? manga.title,
+                chapterOffset: 0
             )
             await TrackerManager.shared.saveTrackItem(item: trackItem)
 
@@ -254,6 +267,7 @@ actor TrackerManager {
                 sourceId: item.sourceId,
                 mangaId: item.mangaId,
                 title: item.title,
+                chapterOffset: item.chapterOffset,
                 context: context
             )
             do {
@@ -271,6 +285,25 @@ actor TrackerManager {
         await CoreDataManager.shared.container.performBackgroundTask { @Sendable context in
             self.removeTrackItem(item: item, context: context)
         }
+    }
+
+    /// Sets the chapter offset for a track item.
+    func setTrackChapterOffset(item: TrackItem, chapterOffset: Int) async {
+        await CoreDataManager.shared.container.performBackgroundTask { context in
+            CoreDataManager.shared.setTrackChapterOffset(
+                trackerId: item.trackerId,
+                sourceId: item.sourceId,
+                mangaId: item.mangaId,
+                chapterOffset: chapterOffset,
+                context: context
+            )
+            do {
+                try context.save()
+            } catch {
+                LogManager.logger.error("TrackManager.setTrackChapterOffset(item:chapterOffset:): \(error)")
+            }
+        }
+        NotificationCenter.default.post(name: .updateTrackers, object: nil)
     }
 
     nonisolated func removeTrackItem(item: TrackItem, context: NSManagedObjectContext) {
@@ -502,6 +535,21 @@ actor TrackerManager {
                 }
             }
         }
+    }
+}
+
+extension TrackerManager {
+    nonisolated static func applyChapterOffset(to chapter: Float, offset: Int, maxChapters: Int?) -> Float {
+        var adjusted = chapter + Float(offset)
+        adjusted = max(0, adjusted)
+        if let maxChapters {
+            adjusted = min(adjusted, Float(maxChapters))
+        }
+        return adjusted
+    }
+
+    private func applyChapterOffset(to chapter: Float, offset: Int, maxChapters: Int?) -> Float {
+        Self.applyChapterOffset(to: chapter, offset: offset, maxChapters: maxChapters)
     }
 }
 

--- a/Shared/Tracking/TrackerManager.swift
+++ b/Shared/Tracking/TrackerManager.swift
@@ -106,21 +106,24 @@ actor TrackerManager {
             // update last read chapter and volume based on mode
             if displayMode == .chapter {
                 // chapter mode: only update chapter, don't update volume
-                if let chapterNum, chapterNum > 0 && state.lastReadChapter ?? 0 < chapterNum {
-                    update.lastReadChapter = applyChapterOffset(
+                if let chapterNum, chapterNum > 0 {
+                    let newChapterNumber = Self.applyChapterOffset(
                         to: chapterNum,
                         offset: item.chapterOffset,
                         maxChapters: state.totalChapters
                     )
+                    if state.lastReadChapter ?? 0 < newChapterNumber {
+                        update.lastReadChapter = newChapterNumber
+                    }
                 } else if let volumeNum {
                     // no chapter metadata, use volume number as chapter
-                    let chapterFromVolume = Float(volumeNum)
+                    let chapterFromVolume = Self.applyChapterOffset(
+                        to: Float(volumeNum),
+                        offset: item.chapterOffset,
+                        maxChapters: state.totalChapters
+                    )
                     if chapterFromVolume > state.lastReadChapter ?? 0 {
-                        update.lastReadChapter = applyChapterOffset(
-                            to: chapterFromVolume,
-                            offset: item.chapterOffset,
-                            maxChapters: state.totalChapters
-                        )
+                        update.lastReadChapter = chapterFromVolume
                     }
                 }
             } else if displayMode == .volume {
@@ -136,12 +139,15 @@ actor TrackerManager {
                 }
             } else {
                 // default mode: update both chapter and volume if available
-                if let chapterNum, chapterNum > 0 && state.lastReadChapter ?? 0 < chapterNum {
-                    update.lastReadChapter = applyChapterOffset(
+                if let chapterNum, chapterNum > 0 {
+                    let newChapterNumber = Self.applyChapterOffset(
                         to: chapterNum,
                         offset: item.chapterOffset,
                         maxChapters: state.totalChapters
                     )
+                    if state.lastReadChapter ?? 0 < newChapterNumber {
+                        update.lastReadChapter = newChapterNumber
+                    }
                 }
                 if let volumeNum, volumeNum > 0 && state.lastReadVolume ?? 0 < volumeNum {
                     update.lastReadVolume = volumeNum
@@ -539,17 +545,13 @@ actor TrackerManager {
 }
 
 extension TrackerManager {
-    nonisolated static func applyChapterOffset(to chapter: Float, offset: Int, maxChapters: Int?) -> Float {
+    static func applyChapterOffset(to chapter: Float, offset: Int, maxChapters: Int?) -> Float {
         var adjusted = chapter + Float(offset)
         adjusted = max(0, adjusted)
         if let maxChapters {
             adjusted = min(adjusted, Float(maxChapters))
         }
         return adjusted
-    }
-
-    private func applyChapterOffset(to chapter: Float, offset: Int, maxChapters: Int?) -> Float {
-        Self.applyChapterOffset(to: chapter, offset: offset, maxChapters: maxChapters)
     }
 }
 

--- a/iOS/Old UI/Manga/Tracking/TrackerView.swift
+++ b/iOS/Old UI/Manga/Tracking/TrackerView.swift
@@ -84,13 +84,13 @@ struct TrackerView: View {
                             showOffsetPicker()
                         } label: {
                             Label(
-                                NSLocalizedString("SET_TRACK_CHAPTER_OFFSET", comment: ""),
+                                NSLocalizedString("SET_TRACK_CHAPTER_OFFSET"),
                                 systemImage: "number"
                             )
                         }
                     } label: {
                         Label(
-                            NSLocalizedString("ADVANCED", comment: ""),
+                            NSLocalizedString("ADVANCED"),
                             systemImage: "slider.horizontal.3"
                         )
                     }
@@ -258,10 +258,12 @@ struct TrackerView: View {
 
         alert.view.addSubview(coordinator.pickerView)
         coordinator.pickerView.translatesAutoresizingMaskIntoConstraints = false
-        coordinator.pickerView.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor).isActive = true
-        coordinator.pickerView.centerYAnchor.constraint(equalTo: alert.view.centerYAnchor, constant: 35).isActive = true
-        coordinator.pickerView.widthAnchor.constraint(equalToConstant: 250).isActive = true
-        coordinator.pickerView.heightAnchor.constraint(equalToConstant: 140).isActive = true
+        NSLayoutConstraint.activate([
+            coordinator.pickerView.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
+            coordinator.pickerView.centerYAnchor.constraint(equalTo: alert.view.centerYAnchor, constant: 35),
+            coordinator.pickerView.widthAnchor.constraint(equalToConstant: 250),
+            coordinator.pickerView.heightAnchor.constraint(equalToConstant: 140),
+        ])
 
         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
             let selectedRow = coordinator.pickerView.selectedRow(inComponent: 0)

--- a/iOS/Old UI/Manga/Tracking/TrackerView.swift
+++ b/iOS/Old UI/Manga/Tracking/TrackerView.swift
@@ -251,21 +251,22 @@ struct TrackerView: View {
         coordinator.pickerView.selectRow(chapterOffset - minValue, inComponent: 0, animated: false)
 
         let alert = UIAlertController(
-            title: NSLocalizedString("SET_TRACK_CHAPTER_OFFSET", comment: ""),
-            message: NSLocalizedString("TRACK_CHAPTER_OFFSET_TEXT", comment: "") + "\n\n\n\n\n\n\n\n",
+            title: NSLocalizedString("SET_TRACK_CHAPTER_OFFSET"),
+            message: NSLocalizedString("TRACK_CHAPTER_OFFSET_TEXT") + "\n\n\n\n\n\n\n\n",
             preferredStyle: .alert
         )
 
         alert.view.addSubview(coordinator.pickerView)
+
         coordinator.pickerView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             coordinator.pickerView.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
             coordinator.pickerView.centerYAnchor.constraint(equalTo: alert.view.centerYAnchor, constant: 35),
             coordinator.pickerView.widthAnchor.constraint(equalToConstant: 250),
-            coordinator.pickerView.heightAnchor.constraint(equalToConstant: 140),
+            coordinator.pickerView.heightAnchor.constraint(equalToConstant: 140)
         ])
 
-        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(UIAlertAction(title: NSLocalizedString("OK"), style: .default) { _ in
             let selectedRow = coordinator.pickerView.selectedRow(inComponent: 0)
             let value = minValue + selectedRow
             guard value != chapterOffset else { return }
@@ -274,7 +275,7 @@ struct TrackerView: View {
                 await TrackerManager.shared.setTrackChapterOffset(item: item, chapterOffset: value)
             }
         })
-        alert.addAction(UIAlertAction(title: NSLocalizedString("CANCEL", comment: ""), style: .cancel, handler: nil))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("CANCEL"), style: .cancel, handler: nil))
 
         (UIApplication.shared.delegate as? AppDelegate)?.visibleViewController?.present(alert, animated: true)
     }

--- a/iOS/Old UI/Manga/Tracking/TrackerView.swift
+++ b/iOS/Old UI/Manga/Tracking/TrackerView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SafariServices
+import UIKit
 
 struct TrackerView: View {
     let tracker: Tracker
@@ -30,6 +31,7 @@ struct TrackerView: View {
 
     @State var safariUrl: URL?
     @State var showSafari = false
+    @State var chapterOffset = 0
 
     var body: some View {
         VStack {
@@ -75,6 +77,21 @@ struct TrackerView: View {
                         Label(
                             NSLocalizedString("SYNC_LOCAL_HISTORY", comment: ""),
                             systemImage: "clock.arrow.circlepath"
+                        )
+                    }
+                    Menu {
+                        Button {
+                            showOffsetPicker()
+                        } label: {
+                            Label(
+                                NSLocalizedString("SET_TRACK_CHAPTER_OFFSET", comment: ""),
+                                systemImage: "number"
+                            )
+                        }
+                    } label: {
+                        Label(
+                            NSLocalizedString("ADVANCED", comment: ""),
+                            systemImage: "slider.horizontal.3"
                         )
                     }
                 } label: {
@@ -193,6 +210,7 @@ struct TrackerView: View {
             }
 
             withAnimation {
+                chapterOffset = item.chapterOffset
                 score = state.score != nil ? info.scoreType == .tenPointDecimal ? Float(state.score!) / 10 : Float(state.score!) : nil
                 scoreOption = newScoreOption
                 statusOption = info.supportedStatuses
@@ -224,6 +242,65 @@ struct TrackerView: View {
         .sheet(isPresented: $showSafari) {
             SafariView(url: $safariUrl)
         }
+    }
+
+    func showOffsetPicker() {
+        let maxValue = 500
+        let minValue = -500
+        let coordinator = TrackerOffsetPickerCoordinator(minValue: minValue, maxValue: maxValue)
+        coordinator.pickerView.selectRow(chapterOffset - minValue, inComponent: 0, animated: false)
+
+        let alert = UIAlertController(
+            title: NSLocalizedString("SET_TRACK_CHAPTER_OFFSET", comment: ""),
+            message: NSLocalizedString("TRACK_CHAPTER_OFFSET_TEXT", comment: "") + "\n\n\n\n\n\n\n\n",
+            preferredStyle: .alert
+        )
+
+        alert.view.addSubview(coordinator.pickerView)
+        coordinator.pickerView.translatesAutoresizingMaskIntoConstraints = false
+        coordinator.pickerView.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor).isActive = true
+        coordinator.pickerView.centerYAnchor.constraint(equalTo: alert.view.centerYAnchor, constant: 35).isActive = true
+        coordinator.pickerView.widthAnchor.constraint(equalToConstant: 250).isActive = true
+        coordinator.pickerView.heightAnchor.constraint(equalToConstant: 140).isActive = true
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default) { _ in
+            let selectedRow = coordinator.pickerView.selectedRow(inComponent: 0)
+            let value = minValue + selectedRow
+            guard value != chapterOffset else { return }
+            chapterOffset = value
+            Task {
+                await TrackerManager.shared.setTrackChapterOffset(item: item, chapterOffset: value)
+            }
+        })
+        alert.addAction(UIAlertAction(title: NSLocalizedString("CANCEL", comment: ""), style: .cancel, handler: nil))
+
+        (UIApplication.shared.delegate as? AppDelegate)?.visibleViewController?.present(alert, animated: true)
+    }
+}
+
+private final class TrackerOffsetPickerCoordinator: NSObject, UIPickerViewDelegate, UIPickerViewDataSource {
+    let minValue: Int
+    let maxValue: Int
+    let pickerView = UIPickerView(frame: CGRect(x: 10, y: 48, width: 250, height: 140))
+
+    init(minValue: Int, maxValue: Int) {
+        self.minValue = minValue
+        self.maxValue = maxValue
+        super.init()
+        pickerView.delegate = self
+        pickerView.dataSource = self
+    }
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        maxValue - minValue + 1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        String(minValue + row)
     }
 }
 


### PR DESCRIPTION
Fixes #910 

Adds a per-title chapter offset for tracker sync to handle source/tracker chapter numbering mismatches (e.g. prologues/bonus chapters)

This was made by adding `Advanced` -> `Set Chapter Offset` to the tracker menu.

Kept manual tracker edits unchanged (offset is not applied there).

Being portuguese I also took the freedom to add localization for pt.


I added `chapterOffset` under a new `0.8.3.xcdatamodel` and updated needed files accordingly. If there is a better approach to this added field please let me know.

The tests ran successfully and I've also tested this manually through an iOS simulator.

Some screenshots for reference:
<img width="468" height="638" alt="image" src="https://github.com/user-attachments/assets/d280c4fa-b2fc-4b1a-91c0-65835bc40771" />
<img width="568" height="676" alt="image" src="https://github.com/user-attachments/assets/70b2fdfa-22c4-476f-a432-dcadb6a08287" />
