### PR TITLE
fix: recover library covers when source URL goes stale

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		FB0051422FB970FF004B4A6F /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0051412FB970FD004B4A6F /* SafariView.swift */; };
 		FB02E1EB288CC1DA00B9E2DE /* LibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02E1EA288CC1DA00B9E2DE /* LibraryViewController.swift */; };
 		FB02E1F2288D7BE900B9E2DE /* MangaGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02E1F1288D7BE900B9E2DE /* MangaGridCell.swift */; };
+		30EAB0012FC051B5000BFEDF /* CoverRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EAB0002FC051B5000BFEDF /* CoverRecovery.swift */; };
 		FB02E1F4288D7C0C00B9E2DE /* Manga.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02E1F3288D7C0C00B9E2DE /* Manga.swift */; };
 		FB034E942EAAB6A90072EEEB /* OIDCLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB034E932EAAB6A50072EEEB /* OIDCLoginController.swift */; };
 		FB034E982EAAFA850072EEEB /* KavitaTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB034E952EAAFA850072EEEB /* KavitaTracker.swift */; };
@@ -634,6 +635,7 @@
 		FB0051412FB970FD004B4A6F /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		FB02E1EA288CC1DA00B9E2DE /* LibraryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewController.swift; sourceTree = "<group>"; };
 		FB02E1F1288D7BE900B9E2DE /* MangaGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaGridCell.swift; sourceTree = "<group>"; };
+		30EAB0002FC051B5000BFEDF /* CoverRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverRecovery.swift; sourceTree = "<group>"; };
 		FB02E1F3288D7C0C00B9E2DE /* Manga.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manga.swift; sourceTree = "<group>"; };
 		FB034E932EAAB6A50072EEEB /* OIDCLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCLoginController.swift; sourceTree = "<group>"; };
 		FB034E952EAAFA850072EEEB /* KavitaTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KavitaTracker.swift; sourceTree = "<group>"; };
@@ -1622,6 +1624,7 @@
 			children = (
 				FBE578F628983C3C00F9F1B5 /* OldMangaCollectionViewController.swift */,
 				FB02E1F1288D7BE900B9E2DE /* MangaGridCell.swift */,
+				30EAB0002FC051B5000BFEDF /* CoverRecovery.swift */,
 			);
 			path = Manga;
 			sourceTree = "<group>";
@@ -2747,6 +2750,7 @@
 				FB0CAA5028A55BB80024561A /* CoreDataManager+Category.swift in Sources */,
 				FB9A48332967E41400FFC414 /* MigrateSelectDestinationView.swift in Sources */,
 				FB02E1F2288D7BE900B9E2DE /* MangaGridCell.swift in Sources */,
+				30EAB0012FC051B5000BFEDF /* CoverRecovery.swift in Sources */,
 				FBF9DC0528205FCE0056FA9A /* DownloadManager.swift in Sources */,
 				7CF79D3D2F31E81300BF0800 /* ReaderPagedTextViewController.swift in Sources */,
 				7CF79D3E2F31E81300BF0800 /* TextPaginator.swift in Sources */,

--- a/AidokuTests/CoverRecoveryTests.swift
+++ b/AidokuTests/CoverRecoveryTests.swift
@@ -1,0 +1,42 @@
+//
+//  CoverRecoveryTests.swift
+//  Aidoku
+//
+//  Created by neldra on 5/24/26.
+//
+
+@testable import Aidoku
+import Foundation
+import Nuke
+import Testing
+
+struct CoverRecoveryTests {
+    @Test func recovers404() {
+        #expect(CoverRecovery.shouldRecover(from: pipelineError(statusCode: 404)))
+    }
+
+    @Test func recovers410() {
+        #expect(CoverRecovery.shouldRecover(from: pipelineError(statusCode: 410)))
+    }
+
+    @Test func recovers403() {
+        #expect(CoverRecovery.shouldRecover(from: pipelineError(statusCode: 403)))
+    }
+
+    @Test func ignores5xx() {
+        #expect(!CoverRecovery.shouldRecover(from: pipelineError(statusCode: 500)))
+    }
+
+    @Test func ignores401And451() {
+        #expect(!CoverRecovery.shouldRecover(from: pipelineError(statusCode: 401)))
+        #expect(!CoverRecovery.shouldRecover(from: pipelineError(statusCode: 451)))
+    }
+
+    @Test func ignoresNonPipelineErrors() {
+        #expect(!CoverRecovery.shouldRecover(from: URLError(.notConnectedToInternet)))
+    }
+
+    private func pipelineError(statusCode: Int) -> ImagePipeline.Error {
+        .dataLoadingFailed(error: DataLoader.Error.statusCodeUnacceptable(statusCode))
+    }
+}

--- a/AidokuTests/TrackerSyncTests.swift
+++ b/AidokuTests/TrackerSyncTests.swift
@@ -68,6 +68,15 @@ actor TestableTracker: Tracker {
 @Suite struct TrackerSyncTests {
     static let testId = "test"
     static let testManga: AidokuRunner.Manga = .init(sourceKey: "test", key: "test", title: "Test")
+    static let testTrackItem = TrackItem(
+        id: Self.testId,
+        trackerId: "test",
+        sourceId: "test",
+        mangaId: "test",
+        title: nil,
+        state: nil,
+        chapterOffset: 0
+    )
 
     @Test func testChapterNumbers() async {
         let tracker = TestableTracker()
@@ -75,7 +84,7 @@ actor TestableTracker: Tracker {
 
         let result = await TrackerManager.shared.getChaptersToSyncProgressFromTracker(
             tracker: tracker,
-            trackId: Self.testId,
+            trackItem: Self.testTrackItem,
             manga: Self.testManga,
             chapters: (1...10).map {
                 .init(
@@ -107,7 +116,7 @@ actor TestableTracker: Tracker {
 
         var result = await TrackerManager.shared.getChaptersToSyncProgressFromTracker(
             tracker: tracker,
-            trackId: Self.testId,
+            trackItem: Self.testTrackItem,
             manga: Self.testManga,
             chapters: chapters,
             currentHighestRead: 0
@@ -120,7 +129,7 @@ actor TestableTracker: Tracker {
 
         result = await TrackerManager.shared.getChaptersToSyncProgressFromTracker(
             tracker: tracker,
-            trackId: Self.testId,
+            trackItem: Self.testTrackItem,
             manga: Self.testManga,
             chapters: chapters,
             currentHighestRead: 0
@@ -144,7 +153,7 @@ actor TestableTracker: Tracker {
 
         var result = await TrackerManager.shared.getChaptersToSyncProgressFromTracker(
             tracker: tracker,
-            trackId: Self.testId,
+            trackItem: Self.testTrackItem,
             manga: Self.testManga,
             chapters: chapters,
             currentHighestRead: 5
@@ -155,7 +164,7 @@ actor TestableTracker: Tracker {
 
         result = await TrackerManager.shared.getChaptersToSyncProgressFromTracker(
             tracker: tracker,
-            trackId: Self.testId,
+            trackItem: Self.testTrackItem,
             manga: Self.testManga,
             chapters: chapters,
             currentHighestRead: 4

--- a/iOS/New/Views/Common/MangaCollectionViewController.swift
+++ b/iOS/New/Views/Common/MangaCollectionViewController.swift
@@ -120,8 +120,7 @@ extension MangaCollectionViewController {
 
     func makeGridCellRegistration() -> GridCellRegistration {
         GridCellRegistration { [weak self] cell, _, manga in
-            cell.sourceId = manga.sourceKey
-            cell.mangaId = manga.key
+            cell.identifier = MangaIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key)
             cell.title = manga.title
             cell.showsBookmark = self?.bookmarkedItems.contains(manga.key) ?? false
             Task {

--- a/iOS/New/Views/Common/MangaListCell.swift
+++ b/iOS/New/Views/Common/MangaListCell.swift
@@ -12,6 +12,7 @@ import UIKit
 
 class MangaListCell: UICollectionViewCell {
     private var sourceId: String?
+    private var mangaId: String?
     private var url: String?
     private var imageTask: ImageTask?
 
@@ -236,6 +237,7 @@ extension MangaListCell {
 extension MangaListCell {
     func configure(with manga: AidokuRunner.Manga, isBookmarked: Bool = false) {
         sourceId = manga.sourceKey
+        mangaId = manga.key
         titleLabel.text = manga.title
         subtitleLabel.text = manga.authors?.joined(separator: ", ")
         subtitleLabel.isHidden = subtitleLabel.text?.isEmpty ?? true
@@ -255,6 +257,7 @@ extension MangaListCell {
 
     func configure(with info: MangaInfo) {
         sourceId = info.sourceId
+        mangaId = info.mangaId
         titleLabel.text = info.title
         subtitleLabel.text = info.author
         subtitleLabel.isHidden = subtitleLabel.text?.isEmpty ?? true
@@ -322,8 +325,16 @@ extension MangaListCell {
                             self.coverImageView.animate(withGIFData: data)
                         }
                     }
-                case .failure:
+                case .failure(let error):
                     imageTask = nil
+                    guard let sourceId, let mangaId else { return }
+                    Task { @MainActor [weak self] in
+                        guard
+                            let newUrl = await CoverRecovery.recover(from: error, sourceId: sourceId, mangaId: mangaId),
+                            self?.sourceId == sourceId, self?.mangaId == mangaId
+                        else { return }
+                        await self?.loadImage(url: newUrl)
+                    }
             }
         }
     }

--- a/iOS/New/Views/Common/MangaListCell.swift
+++ b/iOS/New/Views/Common/MangaListCell.swift
@@ -11,8 +11,7 @@ import Nuke
 import UIKit
 
 class MangaListCell: UICollectionViewCell {
-    private var sourceId: String?
-    private var mangaId: String?
+    private var identifier: MangaIdentifier?
     private var url: String?
     private var imageTask: ImageTask?
 
@@ -236,8 +235,7 @@ extension MangaListCell {
 
 extension MangaListCell {
     func configure(with manga: AidokuRunner.Manga, isBookmarked: Bool = false) {
-        sourceId = manga.sourceKey
-        mangaId = manga.key
+        identifier = MangaIdentifier(sourceKey: manga.sourceKey, mangaKey: manga.key)
         titleLabel.text = manga.title
         subtitleLabel.text = manga.authors?.joined(separator: ", ")
         subtitleLabel.isHidden = subtitleLabel.text?.isEmpty ?? true
@@ -256,8 +254,7 @@ extension MangaListCell {
     }
 
     func configure(with info: MangaInfo) {
-        sourceId = info.sourceId
-        mangaId = info.mangaId
+        identifier = MangaIdentifier(sourceKey: info.sourceId, mangaKey: info.mangaId)
         titleLabel.text = info.title
         subtitleLabel.text = info.author
         subtitleLabel.isHidden = subtitleLabel.text?.isEmpty ?? true
@@ -284,7 +281,7 @@ extension MangaListCell {
         if !cached {
             if let fileUrl = url.toAidokuFileUrl() {
                 urlRequest = URLRequest(url: fileUrl)
-            } else if let sourceId {
+            } else if let sourceId = identifier?.sourceKey {
                 // ensure sources are loaded so we can get the modified image request
                 await SourceManager.shared.waitForSourcesLoad()
                 if let source = SourceManager.shared.source(for: sourceId) {
@@ -327,11 +324,11 @@ extension MangaListCell {
                     }
                 case .failure(let error):
                     imageTask = nil
-                    guard let sourceId, let mangaId else { return }
+                    guard let identifier else { return }
                     Task { @MainActor [weak self] in
                         guard
-                            let newUrl = await CoverRecovery.recover(from: error, sourceId: sourceId, mangaId: mangaId),
-                            self?.sourceId == sourceId, self?.mangaId == mangaId
+                            let newUrl = await CoverRecovery.recover(from: error, identifier: identifier),
+                            self?.identifier == identifier
                         else { return }
                         await self?.loadImage(url: newUrl)
                     }

--- a/iOS/UI/Common/Manga/CoverRecovery.swift
+++ b/iOS/UI/Common/Manga/CoverRecovery.swift
@@ -12,8 +12,16 @@ import Nuke
 enum CoverRecovery {
     private static let staleStatusCodes: Set<Int> = [403, 404, 410]
 
-    private static var attempted = Set<String>()
-    private static let lock = DispatchQueue(label: "app.aidoku.coverRecovery")
+    // dedupes recovery so a stale cover is only refetched once per manga per session
+    private actor AttemptTracker {
+        private var attempted = Set<MangaIdentifier>()
+
+        func claim(_ identifier: MangaIdentifier) -> Bool {
+            attempted.insert(identifier).inserted
+        }
+    }
+
+    private static let tracker = AttemptTracker()
 
     static func shouldRecover(from error: Error) -> Bool {
         guard
@@ -25,16 +33,10 @@ enum CoverRecovery {
         return staleStatusCodes.contains(code)
     }
 
-    static func recover(from error: Error, sourceId: String, mangaId: String) async -> URL? {
+    static func recover(from error: Error, identifier: MangaIdentifier) async -> URL? {
         guard shouldRecover(from: error) else { return nil }
-        let key = "\(sourceId)/\(mangaId)"
-        let firstAttempt = lock.sync { () -> Bool in
-            guard !attempted.contains(key) else { return false }
-            attempted.insert(key)
-            return true
-        }
-        guard firstAttempt else { return nil }
-        let stub = AidokuRunner.Manga(sourceKey: sourceId, key: mangaId, title: "")
+        guard await tracker.claim(identifier) else { return nil }
+        let stub = AidokuRunner.Manga(sourceKey: identifier.sourceKey, key: identifier.mangaKey, title: "")
         guard
             let newCover = await MangaManager.shared.resetCover(manga: stub),
             let url = URL(string: newCover)

--- a/iOS/UI/Common/Manga/CoverRecovery.swift
+++ b/iOS/UI/Common/Manga/CoverRecovery.swift
@@ -1,0 +1,44 @@
+//
+//  CoverRecovery.swift
+//  Aidoku (iOS)
+//
+//  Created by neldra on 5/24/26.
+//
+
+import AidokuRunner
+import Foundation
+import Nuke
+
+enum CoverRecovery {
+    private static let staleStatusCodes: Set<Int> = [403, 404, 410]
+
+    private static var attempted = Set<String>()
+    private static let lock = DispatchQueue(label: "app.aidoku.coverRecovery")
+
+    static func shouldRecover(from error: Error) -> Bool {
+        guard
+            let pipelineError = error as? ImagePipeline.Error,
+            case let .dataLoadingFailed(loadingError) = pipelineError,
+            let dataErr = loadingError as? DataLoader.Error,
+            case let .statusCodeUnacceptable(code) = dataErr
+        else { return false }
+        return staleStatusCodes.contains(code)
+    }
+
+    static func recover(from error: Error, sourceId: String, mangaId: String) async -> URL? {
+        guard shouldRecover(from: error) else { return nil }
+        let key = "\(sourceId)/\(mangaId)"
+        let firstAttempt = lock.sync { () -> Bool in
+            guard !attempted.contains(key) else { return false }
+            attempted.insert(key)
+            return true
+        }
+        guard firstAttempt else { return nil }
+        let stub = AidokuRunner.Manga(sourceKey: sourceId, key: mangaId, title: "")
+        guard
+            let newCover = await MangaManager.shared.resetCover(manga: stub),
+            let url = URL(string: newCover)
+        else { return nil }
+        return url
+    }
+}

--- a/iOS/UI/Common/Manga/MangaGridCell.swift
+++ b/iOS/UI/Common/Manga/MangaGridCell.swift
@@ -11,8 +11,7 @@ import Nuke
 import UIKit
 
 class MangaGridCell: UICollectionViewCell {
-    var sourceId: String?
-    var mangaId: String?
+    var identifier: MangaIdentifier?
 
     var title: String? {
         get {
@@ -252,7 +251,7 @@ extension MangaGridCell {
         if !cached {
             if let fileUrl = url.toAidokuFileUrl() {
                 urlRequest = URLRequest(url: fileUrl)
-            } else if let sourceId {
+            } else if let sourceId = identifier?.sourceKey {
                 // ensure sources are loaded so we can get the modified image request
                 await SourceManager.shared.waitForSourcesLoad()
                 if let source = SourceManager.shared.source(for: sourceId) {
@@ -291,11 +290,11 @@ extension MangaGridCell {
                     }
                 case .failure(let error):
                     imageTask = nil
-                    guard let sourceId, let mangaId else { return }
+                    guard let identifier else { return }
                     Task { @MainActor [weak self] in
                         guard
-                            let newUrl = await CoverRecovery.recover(from: error, sourceId: sourceId, mangaId: mangaId),
-                            self?.sourceId == sourceId, self?.mangaId == mangaId
+                            let newUrl = await CoverRecovery.recover(from: error, identifier: identifier),
+                            self?.identifier == identifier
                         else { return }
                         await self?.loadImage(url: newUrl)
                     }

--- a/iOS/UI/Common/Manga/MangaGridCell.swift
+++ b/iOS/UI/Common/Manga/MangaGridCell.swift
@@ -5,6 +5,7 @@
 //  Created by Skitty on 7/24/22.
 //
 
+import AidokuRunner
 import Gifu
 import Nuke
 import UIKit
@@ -288,8 +289,16 @@ extension MangaGridCell {
                             self.imageView.animate(withGIFData: data)
                         }
                     }
-                case .failure:
+                case .failure(let error):
                     imageTask = nil
+                    guard let sourceId, let mangaId else { return }
+                    Task { @MainActor [weak self] in
+                        guard
+                            let newUrl = await CoverRecovery.recover(from: error, sourceId: sourceId, mangaId: mangaId),
+                            self?.sourceId == sourceId, self?.mangaId == mangaId
+                        else { return }
+                        await self?.loadImage(url: newUrl)
+                    }
             }
         }
     }

--- a/iOS/UI/Common/Manga/OldMangaCollectionViewController.swift
+++ b/iOS/UI/Common/Manga/OldMangaCollectionViewController.swift
@@ -52,8 +52,7 @@ class OldMangaCollectionViewController: BaseCollectionViewController {
 
     // MARK: Cell Registration
     func configure(cell: MangaGridCell, info: MangaInfo, indexPath: IndexPath) {
-        cell.sourceId = info.sourceId
-        cell.mangaId = info.mangaId
+        cell.identifier = MangaIdentifier(sourceKey: info.sourceId, mangaKey: info.mangaId)
         cell.title = info.title
 
         Task {

--- a/iOS/UI/Source/SourceViewController.swift
+++ b/iOS/UI/Source/SourceViewController.swift
@@ -155,8 +155,7 @@ class SourceViewController: OldMangaCollectionViewController {
     }
 
     override func configure(cell: MangaGridCell, info: MangaInfo, indexPath: IndexPath) {
-        cell.sourceId = info.sourceId
-        cell.mangaId = info.mangaId
+        cell.identifier = MangaIdentifier(sourceKey: info.sourceId, mangaKey: info.mangaId)
         cell.title = info.title
         Task {
             let inLibrary = await CoreDataManager.shared.container.performBackgroundTask { context in


### PR DESCRIPTION
Fixes #326.

On HTTP 403/404/410 from a library cover load, refetch manga details via `MangaManager.resetCover` and retry with the fresh URL. Throttled to one attempt per manga per session. Applied to both `MangaGridCell` and `MangaListCell`.

Also includes a small unrelated fix updating `TrackerSyncTests` for the `trackItem` rename in #976, so the test target compiles locally.