### PR TITLE
feat: optimize backup restore time

### DIFF
--- a/Shared/Data/Backup/BackupManager.swift
+++ b/Shared/Data/Backup/BackupManager.swift
@@ -12,48 +12,6 @@ import Foundation
 import UIKit
 #endif
 
-private extension BackupLibraryManga {
-    var identifier: MangaIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId)
-    }
-}
-
-private extension BackupChapter {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: id)
-    }
-}
-
-private extension BackupHistory {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
-    }
-}
-
-private extension BackupUpdate {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
-    }
-}
-
-private extension BackupReadingSession {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
-    }
-}
-
-private extension ChapterObject {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: id)
-    }
-}
-
-private extension HistoryObject {
-    var identifier: ChapterIdentifier {
-        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
-    }
-}
-
 actor BackupManager {
     static let shared = BackupManager()
 
@@ -465,8 +423,8 @@ extension BackupManager {
                     )
                     for backupChapter in backupChapters {
                         let chapter = backupChapter.toObject(context: context)
-                        chapter.manga = mangaByKey[backupChapter.identifier.mangaIdentifier]
-                        chapter.history = historyByKey[backupChapter.identifier]
+                        chapter.manga = mangaByKey[chapter.identifier.mangaIdentifier]
+                        chapter.history = historyByKey[chapter.identifier]
                     }
                     do {
                         try context.save()
@@ -493,7 +451,7 @@ extension BackupManager {
                     )
                     for backupUpdate in backupUpdates {
                         let update = backupUpdate.toObject(context: context)
-                        update.chapter = chaptersByKey[backupUpdate.identifier]
+                        update.chapter = chaptersByKey[update.identifier]
                     }
                     do {
                         try context.save()

--- a/Shared/Data/Backup/BackupManager.swift
+++ b/Shared/Data/Backup/BackupManager.swift
@@ -12,6 +12,72 @@ import Foundation
 import UIKit
 #endif
 
+struct BackupRestoreMangaKey: Hashable, Sendable {
+    let sourceId: String
+    let mangaId: String
+
+    init(sourceId: String, mangaId: String) {
+        self.sourceId = sourceId
+        self.mangaId = mangaId
+    }
+
+    init(_ manga: BackupManga) {
+        self.init(sourceId: manga.sourceId, mangaId: manga.id)
+    }
+
+    init(_ libraryManga: BackupLibraryManga) {
+        self.init(sourceId: libraryManga.sourceId, mangaId: libraryManga.mangaId)
+    }
+
+    init(_ mangaObject: MangaObject) {
+        self.init(sourceId: mangaObject.sourceId, mangaId: mangaObject.id)
+    }
+}
+
+struct BackupRestoreChapterKey: Hashable, Sendable {
+    let sourceId: String
+    let mangaId: String
+    let chapterId: String
+
+    init(sourceId: String, mangaId: String, chapterId: String) {
+        self.sourceId = sourceId
+        self.mangaId = mangaId
+        self.chapterId = chapterId
+    }
+
+    init(_ chapter: BackupChapter) {
+        self.init(sourceId: chapter.sourceId, mangaId: chapter.mangaId, chapterId: chapter.id)
+    }
+
+    init(_ history: BackupHistory) {
+        self.init(sourceId: history.sourceId, mangaId: history.mangaId, chapterId: history.chapterId)
+    }
+
+    init(_ update: BackupUpdate) {
+        self.init(sourceId: update.sourceId, mangaId: update.mangaId, chapterId: update.chapterId)
+    }
+
+    init(_ session: BackupReadingSession) {
+        self.init(sourceId: session.sourceId, mangaId: session.mangaId, chapterId: session.chapterId)
+    }
+
+    init(_ chapterObject: ChapterObject) {
+        self.init(
+            sourceId: chapterObject.sourceId,
+            mangaId: chapterObject.mangaId,
+            chapterId: chapterObject.id
+        )
+    }
+
+    init(_ historyObject: HistoryObject) {
+        self.init(
+            sourceId: historyObject.sourceId,
+            mangaId: historyObject.mangaId,
+            chapterId: historyObject.chapterId
+        )
+    }
+}
+
 actor BackupManager {
     static let shared = BackupManager()
 
@@ -350,20 +416,25 @@ extension BackupManager {
             try await categoriesTask.value
             if let backupLibrary = backup.library {
                 let result = await CoreDataManager.shared.container.performBackgroundTask { context in
-                    let manga = CoreDataManager.shared.getManga(context: context)
+                    CoreDataManager.shared.clearLibrary(context: context)
+                    let mangaByKey = Dictionary(
+                        CoreDataManager.shared.getManga(context: context).map {
+                            (BackupRestoreMangaKey($0), $0)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                    let categoryByTitle = Dictionary(
+                        CoreDataManager.shared.getCategories(context: context).compactMap { category in
+                            category.title.map { ($0, category) }
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                     for libraryBackupItem in backupLibrary {
                         let libraryObject = libraryBackupItem.toObject(context: context)
-                        if let manga = manga.first(where: {
-                            $0.id == libraryBackupItem.mangaId && $0.sourceId == libraryBackupItem.sourceId
-                        }) {
+                        if let manga = mangaByKey[BackupRestoreMangaKey(libraryBackupItem)] {
                             libraryObject.manga = manga
                             if let categories = libraryBackupItem.categories, !categories.isEmpty {
-                                CoreDataManager.shared.addCategoriesToManga(
-                                    sourceId: libraryBackupItem.sourceId,
-                                    mangaId: libraryBackupItem.mangaId,
-                                    categories: categories,
-                                    context: context
-                                )
+                                libraryObject.categories = NSSet(array: categories.compactMap { categoryByTitle[$0] })
                             }
                         }
                     }
@@ -404,18 +475,25 @@ extension BackupManager {
             if let backupChapters = backup.chapters {
                 let result = await CoreDataManager.shared.container.performBackgroundTask { context in
                     CoreDataManager.shared.clearChapters(context: context)
-                    let manga = CoreDataManager.shared.getManga(context: context)
-                    let history = CoreDataManager.shared.getHistory(context: context)
+                    let mangaByKey = Dictionary(
+                        CoreDataManager.shared.getManga(context: context).map {
+                            (BackupRestoreMangaKey($0), $0)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                    let historyByKey = Dictionary(
+                        CoreDataManager.shared.getHistory(context: context).map {
+                            (BackupRestoreChapterKey($0), $0)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                     for backupChapter in backupChapters {
                         let chapter = backupChapter.toObject(context: context)
-                        chapter.manga = manga.first {
-                            $0.id == backupChapter.mangaId && $0.sourceId == backupChapter.sourceId
-                        }
-                        chapter.history = history.first {
-                            $0.chapterId == backupChapter.id
-                                && $0.mangaId == backupChapter.mangaId
-                                && $0.sourceId == backupChapter.sourceId
-                        }
+                        chapter.manga = mangaByKey[BackupRestoreMangaKey(
+                            sourceId: backupChapter.sourceId,
+                            mangaId: backupChapter.mangaId
+                        )]
+                        chapter.history = historyByKey[BackupRestoreChapterKey(backupChapter)]
                     }
                     do {
                         try context.save()
@@ -434,14 +512,15 @@ extension BackupManager {
             if let backupUpdates = backup.updates {
                 let result = await CoreDataManager.shared.container.performBackgroundTask { context in
                     CoreDataManager.shared.clearUpdates(context: context)
-                    let chapters = CoreDataManager.shared.getChapters(context: context)
+                    let chaptersByKey = Dictionary(
+                        CoreDataManager.shared.getChapters(context: context).map {
+                            (BackupRestoreChapterKey($0), $0)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                     for backupUpdate in backupUpdates {
                         let update = backupUpdate.toObject(context: context)
-                        update.chapter = chapters.first {
-                            $0.id == backupUpdate.chapterId
-                                && $0.mangaId == backupUpdate.mangaId
-                                && $0.sourceId == backupUpdate.sourceId
-                        }
+                        update.chapter = chaptersByKey[BackupRestoreChapterKey(backupUpdate)]
                     }
                     do {
                         try context.save()
@@ -460,18 +539,19 @@ extension BackupManager {
             if let backupSessions = backup.readingSessions {
                 let result = await CoreDataManager.shared.container.performBackgroundTask { context in
                     CoreDataManager.shared.clearSessions(context: context)
-                    let history = CoreDataManager.shared.getHistory(context: context)
+                    let historyByKey = Dictionary(
+                        CoreDataManager.shared.getHistory(context: context).map {
+                            (BackupRestoreChapterKey($0), $0)
+                        },
+                        uniquingKeysWith: { first, _ in first }
+                    )
                     for backupSession in backupSessions {
                         // ensure data is valid
                         guard backupSession.endDate > backupSession.startDate && backupSession.pagesRead > 0 else {
                             continue
                         }
                         let session = backupSession.toObject(context: context)
-                        session.history = history.first {
-                            $0.chapterId == backupSession.chapterId
-                                && $0.mangaId == backupSession.mangaId
-                                && $0.sourceId == backupSession.sourceId
-                        }
+                        session.history = historyByKey[BackupRestoreChapterKey(backupSession)]
                     }
                     do {
                         try context.save()

--- a/Shared/Data/Backup/BackupManager.swift
+++ b/Shared/Data/Backup/BackupManager.swift
@@ -12,69 +12,45 @@ import Foundation
 import UIKit
 #endif
 
-struct BackupRestoreMangaKey: Hashable, Sendable {
-    let sourceId: String
-    let mangaId: String
-
-    init(sourceId: String, mangaId: String) {
-        self.sourceId = sourceId
-        self.mangaId = mangaId
-    }
-
-    init(_ manga: BackupManga) {
-        self.init(sourceId: manga.sourceId, mangaId: manga.id)
-    }
-
-    init(_ libraryManga: BackupLibraryManga) {
-        self.init(sourceId: libraryManga.sourceId, mangaId: libraryManga.mangaId)
-    }
-
-    init(_ mangaObject: MangaObject) {
-        self.init(sourceId: mangaObject.sourceId, mangaId: mangaObject.id)
+private extension BackupLibraryManga {
+    var identifier: MangaIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId)
     }
 }
 
-struct BackupRestoreChapterKey: Hashable, Sendable {
-    let sourceId: String
-    let mangaId: String
-    let chapterId: String
-
-    init(sourceId: String, mangaId: String, chapterId: String) {
-        self.sourceId = sourceId
-        self.mangaId = mangaId
-        self.chapterId = chapterId
+private extension BackupChapter {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: id)
     }
+}
 
-    init(_ chapter: BackupChapter) {
-        self.init(sourceId: chapter.sourceId, mangaId: chapter.mangaId, chapterId: chapter.id)
+private extension BackupHistory {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
     }
+}
 
-    init(_ history: BackupHistory) {
-        self.init(sourceId: history.sourceId, mangaId: history.mangaId, chapterId: history.chapterId)
+private extension BackupUpdate {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
     }
+}
 
-    init(_ update: BackupUpdate) {
-        self.init(sourceId: update.sourceId, mangaId: update.mangaId, chapterId: update.chapterId)
+private extension BackupReadingSession {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
     }
+}
 
-    init(_ session: BackupReadingSession) {
-        self.init(sourceId: session.sourceId, mangaId: session.mangaId, chapterId: session.chapterId)
+private extension ChapterObject {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: id)
     }
+}
 
-    init(_ chapterObject: ChapterObject) {
-        self.init(
-            sourceId: chapterObject.sourceId,
-            mangaId: chapterObject.mangaId,
-            chapterId: chapterObject.id
-        )
-    }
-
-    init(_ historyObject: HistoryObject) {
-        self.init(
-            sourceId: historyObject.sourceId,
-            mangaId: historyObject.mangaId,
-            chapterId: historyObject.chapterId
-        )
+private extension HistoryObject {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
     }
 }
 
@@ -419,7 +395,7 @@ extension BackupManager {
                     CoreDataManager.shared.clearLibrary(context: context)
                     let mangaByKey = Dictionary(
                         CoreDataManager.shared.getManga(context: context).map {
-                            (BackupRestoreMangaKey($0), $0)
+                            ($0.identifier, $0)
                         },
                         uniquingKeysWith: { first, _ in first }
                     )
@@ -431,7 +407,7 @@ extension BackupManager {
                     )
                     for libraryBackupItem in backupLibrary {
                         let libraryObject = libraryBackupItem.toObject(context: context)
-                        if let manga = mangaByKey[BackupRestoreMangaKey(libraryBackupItem)] {
+                        if let manga = mangaByKey[libraryBackupItem.identifier] {
                             libraryObject.manga = manga
                             if let categories = libraryBackupItem.categories, !categories.isEmpty {
                                 libraryObject.categories = NSSet(array: categories.compactMap { categoryByTitle[$0] })
@@ -477,23 +453,20 @@ extension BackupManager {
                     CoreDataManager.shared.clearChapters(context: context)
                     let mangaByKey = Dictionary(
                         CoreDataManager.shared.getManga(context: context).map {
-                            (BackupRestoreMangaKey($0), $0)
+                            ($0.identifier, $0)
                         },
                         uniquingKeysWith: { first, _ in first }
                     )
                     let historyByKey = Dictionary(
                         CoreDataManager.shared.getHistory(context: context).map {
-                            (BackupRestoreChapterKey($0), $0)
+                            ($0.identifier, $0)
                         },
                         uniquingKeysWith: { first, _ in first }
                     )
                     for backupChapter in backupChapters {
                         let chapter = backupChapter.toObject(context: context)
-                        chapter.manga = mangaByKey[BackupRestoreMangaKey(
-                            sourceId: backupChapter.sourceId,
-                            mangaId: backupChapter.mangaId
-                        )]
-                        chapter.history = historyByKey[BackupRestoreChapterKey(backupChapter)]
+                        chapter.manga = mangaByKey[backupChapter.identifier.mangaIdentifier]
+                        chapter.history = historyByKey[backupChapter.identifier]
                     }
                     do {
                         try context.save()
@@ -514,13 +487,13 @@ extension BackupManager {
                     CoreDataManager.shared.clearUpdates(context: context)
                     let chaptersByKey = Dictionary(
                         CoreDataManager.shared.getChapters(context: context).map {
-                            (BackupRestoreChapterKey($0), $0)
+                            ($0.identifier, $0)
                         },
                         uniquingKeysWith: { first, _ in first }
                     )
                     for backupUpdate in backupUpdates {
                         let update = backupUpdate.toObject(context: context)
-                        update.chapter = chaptersByKey[BackupRestoreChapterKey(backupUpdate)]
+                        update.chapter = chaptersByKey[backupUpdate.identifier]
                     }
                     do {
                         try context.save()
@@ -541,7 +514,7 @@ extension BackupManager {
                     CoreDataManager.shared.clearSessions(context: context)
                     let historyByKey = Dictionary(
                         CoreDataManager.shared.getHistory(context: context).map {
-                            (BackupRestoreChapterKey($0), $0)
+                            ($0.identifier, $0)
                         },
                         uniquingKeysWith: { first, _ in first }
                     )
@@ -551,7 +524,7 @@ extension BackupManager {
                             continue
                         }
                         let session = backupSession.toObject(context: context)
-                        session.history = historyByKey[BackupRestoreChapterKey(backupSession)]
+                        session.history = historyByKey[backupSession.identifier]
                     }
                     do {
                         try context.save()

--- a/Shared/Data/Backup/Models/BackupLibraryManga.swift
+++ b/Shared/Data/Backup/Models/BackupLibraryManga.swift
@@ -19,6 +19,10 @@ struct BackupLibraryManga: Codable, Hashable {
     var mangaId: String
     var sourceId: String
 
+    var identifier: MangaIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId)
+    }
+
     init(libraryObject: LibraryMangaObject, skipCategories: Bool = false) {
         lastOpened = libraryObject.lastOpened
         lastUpdated = libraryObject.lastUpdated

--- a/Shared/Data/Backup/Models/BackupReadingSession.swift
+++ b/Shared/Data/Backup/Models/BackupReadingSession.swift
@@ -11,9 +11,14 @@ struct BackupReadingSession: Codable, Hashable {
     var pagesRead: Int
     var startDate: Date
     var endDate: Date
+
     var sourceId: String
     var mangaId: String
     var chapterId: String
+
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
+    }
 
     init?(_ object: ReadingSessionObject) {
         guard
@@ -27,8 +32,8 @@ struct BackupReadingSession: Codable, Hashable {
         self.startDate = startDate
         self.endDate = endDate
         sourceId = history.sourceId
-        chapterId = history.chapterId
         mangaId = history.mangaId
+        chapterId = history.chapterId
     }
 
     func toObject(context: NSManagedObjectContext? = nil) -> ReadingSessionObject {

--- a/Shared/Data/Database/Objects/ChapterObject.swift
+++ b/Shared/Data/Database/Objects/ChapterObject.swift
@@ -11,6 +11,10 @@ import AidokuRunner
 
 @objc(ChapterObject)
 public class ChapterObject: NSManagedObject {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: id)
+    }
+
     func load(
         from chapter: AidokuRunner.Chapter,
         sourceId: String,

--- a/Shared/Data/Database/Objects/HistoryObject.swift
+++ b/Shared/Data/Database/Objects/HistoryObject.swift
@@ -10,6 +10,9 @@ import CoreData
 
 @objc(HistoryObject)
 public class HistoryObject: NSManagedObject {
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId, mangaKey: mangaId, chapterKey: chapterId)
+    }
 
     public override func awakeFromInsert() {
         super.awakeFromInsert()

--- a/Shared/Data/Database/Objects/MangaUpdateObject.swift
+++ b/Shared/Data/Database/Objects/MangaUpdateObject.swift
@@ -12,6 +12,10 @@ extension MangaUpdateObject {
         (sourceId ?? "") + (chapterId ?? "") + (mangaId ?? "")
     }
 
+    var identifier: ChapterIdentifier {
+        .init(sourceKey: sourceId ?? "", mangaKey: mangaId ?? "", chapterKey: chapterId ?? "")
+    }
+
     func toItem() -> MangaUpdateItem {
         MangaUpdateItem(
             sourceId: sourceId,


### PR DESCRIPTION
use a dictionary with lookup keys instead of repeated linear scans

this speeds up restore times massively

tested on:
1184 library entries
62906 history entries
128501 chapters

before took 17 minutes to fully restore, now takes 10 seconds