### PR TITLE
Fix Core Data launch deadlock from concurrent stack initialization

### DIFF
--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -205,6 +205,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ]
         )
 
+        // PlayCover fix: eagerly initialize the Core Data stack on the main thread
+        // before any background migration task touches it. The `lazy var container`
+        // and the singleton's init are not thread-safe; under PlayCover's timing the
+        // main thread and a background migration task race to initialize them, and the
+        // persistent-history remote-change observer's performAndWait deadlocks the
+        // launch (no window ever appears). Forcing first init on the main thread here
+        // makes the main thread win the race deterministically.
+        _ = CoreDataManager.shared
+
         // check for icloud availability
         // https://developer.apple.com/documentation/foundation/filemanager/url(forubiquitycontaineridentifier:)
         // Do not call this method from your app’s main thread. Because this method might take a nontrivial amount of


### PR DESCRIPTION
## Problem

`CoreDataManager`'s `lazy var container` and its `init()` are not thread-safe. At launch, `AppDelegate.application(_:didFinishLaunchingWithOptions:)` spawns background migration `Task`s (`performMigration()`, etc.) that touch `CoreDataManager.shared.container` **concurrently** with the main thread's UI setup.

While `loadPersistentStores` runs, the persistent-history `.NSPersistentStoreRemoteChange` observer fires `performAndWait`. This creates a deadlock window:

- the **background** migration thread holds the lazy var's `dispatch_once` and ends up waiting on the main queue, while
- the **main** thread waits on that same `dispatch_once` (`_dispatch_once_wait`).

On a real device the main thread usually wins this race, so it rarely manifests. But the timing is different under [PlayCover](https://github.com/PlayCover/PlayCover) (running the iOS build on Apple Silicon macOS), where it deadlocks **deterministically** — the app launches, never creates its window, and appears hung. A `sample` of the stuck process shows the main thread parked in `_dispatch_once_wait` and a background thread inside `-[NSManagedObjectContext performBlockAndWait:]`.

## Fix

Eagerly initialize the Core Data stack on the **main thread** in `didFinishLaunching`, before any background migration task can touch it, so the main thread deterministically wins the initialization race:

```swift
_ = CoreDataManager.shared
```

This is a minimal, low-risk change — it only forces the (already-inevitable) first access to happen on the main thread up front. No behavior change on devices where the race was already being won.

## Testing

- Built the iOS target and ran it under PlayCover on macOS: **before** the patch the app hangs on launch with no window; **after**, it launches, renders the Library, and is fully interactive.