### PR TITLE
feat: add initial epub support

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -542,6 +542,8 @@
 		FBE88BF02886FC5800A61122 /* TrackerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE88BEF2886FC5800A61122 /* TrackerListView.swift */; };
 		FBE975CC2EC3932D008C7633 /* ComicInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE975CB2EC39329008C7633 /* ComicInfo.swift */; };
 		FBE975CD2EC3932D008C7633 /* ComicInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE975CB2EC39329008C7633 /* ComicInfo.swift */; };
+		FBE9B0022E0000010019A551 /* EpubParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE9B0012E0000010019A551 /* EpubParser.swift */; };
+		FBE9B0032E0000010019A551 /* EpubParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE9B0012E0000010019A551 /* EpubParser.swift */; };
 		FBECCECF2DE0C845007D5467 /* KomgaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBECCECE2DE0C842007D5467 /* KomgaModels.swift */; };
 		FBECCED02DE0C845007D5467 /* KomgaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBECCECE2DE0C842007D5467 /* KomgaModels.swift */; };
 		FBED231727B83B670095D0C0 /* UISwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBED231627B83B670095D0C0 /* UISwitch.swift */; };
@@ -1037,6 +1039,7 @@
 		FBE7A5932DE35AB700CA5B60 /* CustomSourceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSourceConfig.swift; sourceTree = "<group>"; };
 		FBE88BEF2886FC5800A61122 /* TrackerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerListView.swift; sourceTree = "<group>"; };
 		FBE975CB2EC39329008C7633 /* ComicInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComicInfo.swift; sourceTree = "<group>"; };
+		FBE9B0012E0000010019A551 /* EpubParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpubParser.swift; sourceTree = "<group>"; };
 		FBECCECE2DE0C842007D5467 /* KomgaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomgaModels.swift; sourceTree = "<group>"; };
 		FBED14542819FCFC004B8050 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FBED1455281A2B9D004B8050 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -1680,6 +1683,7 @@
 			children = (
 				FB55C0B12DF244550019A551 /* LocalSource.swift */,
 				FB55C0B72DF32B9E0019A551 /* LocalFileManager.swift */,
+				FBE9B0012E0000010019A551 /* EpubParser.swift */,
 				FB82A5C52DF874D100366BC8 /* LocalFileDataManager.swift */,
 				FB82A5C22DF8622500366BC8 /* LocalModels.swift */,
 				FBB44E6B2EC634AD0032EFBB /* LocalFileNameParser.swift */,
@@ -2851,6 +2855,7 @@
 				FB662EC22DA813E300007514 /* HomeScrollerView.swift in Sources */,
 				723D3AFA2E0DC5A5003ED4CF /* DownloadedMangaInfo.swift in Sources */,
 				FB55C0B92DF32BA20019A551 /* LocalFileManager.swift in Sources */,
+				FBE9B0032E0000010019A551 /* EpubParser.swift in Sources */,
 				FB662EC52DA813E300007514 /* WrappingHStack.swift in Sources */,
 				FB662EC62DA813E300007514 /* SourceListingViewController.swift in Sources */,
 				FB662EC72DA813E300007514 /* PlatformNavigationStack.swift in Sources */,
@@ -3062,6 +3067,7 @@
 				FB1B486B277CE76B0056D02C /* Page.swift in Sources */,
 				FBE7812D282F533C0038C0E3 /* DownloadQueue.swift in Sources */,
 				FB55C0B82DF32BA20019A551 /* LocalFileManager.swift in Sources */,
+				FBE9B0022E0000010019A551 /* EpubParser.swift in Sources */,
 				FBF9DC0628205FCE0056FA9A /* DownloadManager.swift in Sources */,
 				FBCA1B252888A910007149C5 /* TrackObject.swift in Sources */,
 				FB034EA12EAC27510072EEEB /* ChapterIdentifier.swift in Sources */,

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -217,7 +217,7 @@
 "IMPORT" = "Import";
 "IMPORT_FILE" = "Import File";
 "LOCAL_FILE_IMPORT" = "Local File Import";
-"LOCAL_FILE_IMPORT_TEXT" = "Import a CBZ, ePub or ZIP file containing images to read.";
+"LOCAL_FILE_IMPORT_TEXT" = "Import a CBZ, ePub, or ZIP file containing images to read.";
 "CHAPTER_TITLE" = "Chapter Title";
 "SERIES_TITLE" = "Series Title";
 "DESCRIPTION" = "Description";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -217,7 +217,7 @@
 "IMPORT" = "Import";
 "IMPORT_FILE" = "Import File";
 "LOCAL_FILE_IMPORT" = "Local File Import";
-"LOCAL_FILE_IMPORT_TEXT" = "Import a CBZ or ZIP file containing images to read.";
+"LOCAL_FILE_IMPORT_TEXT" = "Import a CBZ, ePub or ZIP file containing images to read.";
 "CHAPTER_TITLE" = "Chapter Title";
 "SERIES_TITLE" = "Series Title";
 "DESCRIPTION" = "Description";
@@ -235,6 +235,7 @@
 "1_PAGE" = "1 page";
 "CBZ_NAME" = "Comic Book Zip Archive";
 "ZIP_NAME" = "Zip Archive";
+"EPUB_NAME" = "EPUB";
 
 // Komga
 "KOMGA" = "Komga";

--- a/Shared/Sources/Local/EpubParser.swift
+++ b/Shared/Sources/Local/EpubParser.swift
@@ -1,0 +1,481 @@
+//
+//  EpubParser.swift
+//  Aidoku
+//
+//  Minimal EPUB 2/3 parser for the local files source.
+//  Extracts book metadata, the spine (reading order), chapter titles from the
+//  TOC, the cover image, and converts chapter XHTML into text and image
+//  segments for the reader.
+//
+//  XML element lookups match on local names so that namespace-prefixed
+//  packages (e.g. <opf:item>, <odc:rootfile>) parse the same as unprefixed ones.
+//
+
+import Foundation
+import SwiftSoup
+import ZIPFoundation
+
+enum EpubParser {
+    struct Book {
+        var title: String?
+        var author: String?
+        var description: String?
+        var coverData: Data?
+        /// Chapters in spine (reading) order.
+        var chapters: [Chapter]
+    }
+
+    struct Chapter {
+        /// Paths of the chapter's content files within the archive, in reading order.
+        /// Spine files without a TOC entry are grouped into the preceding chapter.
+        let hrefs: [String]
+        let title: String?
+
+        /// Path of the primary (first) content file, used as the chapter identifier.
+        var href: String { hrefs[0] }
+    }
+
+    /// A piece of chapter content, in document order.
+    enum Segment {
+        case text(String)
+        /// Archive path of an image referenced by the chapter.
+        case image(String)
+    }
+
+    // MARK: - Parsing
+
+    static func parse(url: URL) -> Book? {
+        let archive: Archive
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
+            LogManager.logger.error("EpubParser: failed to open archive \(url.lastPathComponent): \(error)")
+            return nil
+        }
+        return parse(archive: archive)
+    }
+
+    static func parse(archive: Archive) -> Book? {
+        // container.xml points to the OPF package document
+        guard
+            let containerXml = extractString(from: archive, path: "META-INF/container.xml"),
+            let container = try? SwiftSoup.parse(containerXml, "", Parser.xmlParser())
+        else {
+            LogManager.logger.error("EpubParser: missing or unreadable META-INF/container.xml")
+            return nil
+        }
+        guard
+            let opfPath = elements("rootfile", in: container).first.flatMap({ attr($0, "full-path") }),
+            let opfXml = extractString(from: archive, path: opfPath),
+            let opf = try? SwiftSoup.parse(opfXml, "", Parser.xmlParser())
+        else {
+            LogManager.logger.error("EpubParser: missing or unreadable OPF package document")
+            return nil
+        }
+
+        let opfDir = directory(of: opfPath)
+
+        // metadata
+        let metadata = elements("metadata", in: opf).first
+        let title = metadata.flatMap { elements("title", in: $0).first.flatMap { try? $0.text() } }
+        let author = metadata.flatMap { elements("creator", in: $0).first.flatMap { try? $0.text() } }
+        let description = metadata.flatMap { elements("description", in: $0).first.flatMap { try? $0.text() } }
+
+        // manifest: id -> href
+        var manifestHrefs: [String: String] = [:]
+        var coverHref: String?
+        var navHref: String?
+        for item in elements("manifest", in: opf).flatMap({ elements("item", in: $0) }) {
+            guard let id = attr(item, "id"), let href = attr(item, "href") else { continue }
+            manifestHrefs[id] = href
+            let properties = attr(item, "properties") ?? ""
+            if properties.contains("cover-image") {
+                coverHref = href
+            }
+            if properties.contains("nav") {
+                navHref = href
+            }
+        }
+
+        // EPUB 2 cover: <meta name="cover" content="manifest-id">
+        if coverHref == nil, let metadata {
+            let coverId = elements("meta", in: metadata)
+                .first { attr($0, "name") == "cover" }
+                .flatMap { attr($0, "content") }
+            if let coverId, let href = manifestHrefs[coverId] {
+                coverHref = href
+            }
+        }
+
+        // chapter titles from the TOC (EPUB 3 nav document or EPUB 2 NCX)
+        var titles: [String: String] = [:]
+        if let navHref {
+            let navPath = resolve(href: navHref, relativeTo: opfDir)
+            titles = navTitles(from: archive, navPath: navPath)
+        }
+        if titles.isEmpty {
+            let ncxId = elements("spine", in: opf).first.flatMap { attr($0, "toc") }
+            let ncxHref = ncxId.flatMap { manifestHrefs[$0] }
+                ?? manifestHrefs.values.first { $0.lowercased().hasSuffix(".ncx") }
+            if let ncxHref {
+                let ncxPath = resolve(href: ncxHref, relativeTo: opfDir)
+                titles = ncxTitles(from: archive, ncxPath: ncxPath)
+            }
+        }
+
+        // spine defines the reading order; group files without a TOC entry
+        // (illustrations, chapter continuations) into the preceding chapter
+        var chapters: [Chapter] = []
+        var currentHrefs: [String] = []
+        var currentTitle: String?
+        func flushChapter() {
+            if !currentHrefs.isEmpty {
+                chapters.append(Chapter(hrefs: currentHrefs, title: currentTitle))
+            }
+            currentHrefs = []
+            currentTitle = nil
+        }
+        let hasTitles = !titles.isEmpty
+        for itemref in elements("spine", in: opf).flatMap({ elements("itemref", in: $0) }) {
+            guard
+                attr(itemref, "linear") != "no",
+                let idref = attr(itemref, "idref"),
+                let href = manifestHrefs[idref]
+            else { continue }
+            let path = resolve(href: href, relativeTo: opfDir)
+            let title = titles[path]
+            // without a toc, every file is its own chapter
+            if !hasTitles || title != nil {
+                flushChapter()
+                currentTitle = title
+            }
+            currentHrefs.append(path)
+        }
+        flushChapter()
+
+        if chapters.isEmpty {
+            LogManager.logger.error("EpubParser: no readable chapters found in spine")
+        }
+
+        let coverData = coverHref.flatMap {
+            extractData(from: archive, path: resolve(href: $0, relativeTo: opfDir))
+        }
+
+        return Book(
+            title: title?.isEmpty == true ? nil : title,
+            author: author?.isEmpty == true ? nil : author,
+            description: description?.isEmpty == true ? nil : description,
+            coverData: coverData,
+            chapters: chapters
+        )
+    }
+
+    // MARK: - Chapter Content
+
+    /// Extract a chapter's XHTML from the archive and convert it into
+    /// text (markdown) and image segments in document order.
+    /// `href` identifies the chapter by its primary content file; grouped
+    /// continuation files are included automatically.
+    static func chapterSegments(url: URL, href: String) -> [Segment] {
+        let archive: Archive
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
+            LogManager.logger.error("EpubParser: failed to open archive \(url.lastPathComponent): \(error)")
+            return []
+        }
+
+        // resolve the full file group for this chapter
+        let hrefs = parse(archive: archive)?
+            .chapters.first { $0.href == href }?
+            .hrefs ?? [href]
+
+        var segments: [Segment] = []
+        for href in hrefs {
+            guard let html = extractString(from: archive, path: href) else {
+                LogManager.logger.error("EpubParser: failed to extract chapter file \(href)")
+                continue
+            }
+            segments += self.segments(fromHTML: html, basePath: directory(of: href))
+        }
+
+        let hasText = segments.contains {
+            if case .text = $0 { return true }
+            return false
+        }
+
+        // drop images that don't exist in the archive, and drop small decorative
+        // images (scene dividers, ornaments, logos) when the chapter has text —
+        // otherwise every chapter becomes mixed content and can't use the
+        // paginated text reader
+        // ponytail: 100 KB size heuristic; full-page illustrations in text
+        // chapters are practically always larger
+        let filtered: [Segment] = segments.compactMap { segment in
+            guard case let .image(path) = segment else { return segment }
+            guard let entry = entry(in: archive, path: path) else { return nil }
+            if hasText && entry.uncompressedSize < 100_000 { return nil }
+            return segment
+        }
+
+        // merge adjacent text segments (left over after dropping images) so
+        // text-only chapters always produce a single text page
+        var merged: [Segment] = []
+        for segment in filtered {
+            if case let .text(text) = segment, case let .text(previous)? = merged.last {
+                merged[merged.count - 1] = .text(previous + "\n\n" + text)
+            } else {
+                merged.append(segment)
+            }
+        }
+        return merged
+    }
+
+    /// Convert chapter XHTML to segments: markdown text (headings, blockquotes,
+    /// list items, emphasis) interleaved with referenced images.
+    static func segments(fromHTML html: String, basePath: String) -> [Segment] {
+        guard
+            let doc = try? SwiftSoup.parse(html),
+            let body = doc.body()
+        else { return [Segment.text(html)] }
+
+        var segments: [Segment] = []
+        var pendingText: [String] = []
+
+        func flushText() {
+            if !pendingText.isEmpty {
+                segments.append(.text(pendingText.joined(separator: "\n\n")))
+                pendingText = []
+            }
+        }
+
+        func appendImage(_ element: Element) {
+            if let path = imagePath(of: element, basePath: basePath) {
+                flushText()
+                segments.append(.image(path))
+            }
+        }
+
+        func walk(_ element: Element) {
+            for node in element.getChildNodes() {
+                guard let child = node as? Element else { continue }
+                let tag = localName(child)
+
+                if tag == "img" || tag == "image" {
+                    // "image" covers svg <image xlink:href=...> elements
+                    appendImage(child)
+                } else if blockTags.contains(tag) {
+                    let text = inlineMarkdown(of: child).trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !text.isEmpty {
+                        switch tag {
+                            case "h1", "h2", "h3", "h4", "h5", "h6":
+                                let level = Int(String(tag.dropFirst())) ?? 1
+                                pendingText.append(String(repeating: "#", count: level) + " " + text)
+                            case "blockquote":
+                                pendingText.append("> " + text)
+                            case "li":
+                                pendingText.append("- " + text)
+                            default:
+                                pendingText.append(text)
+                        }
+                    }
+                    // emit images contained in the block after its text
+                    for img in (try? child.select("img, image").array()) ?? [] {
+                        appendImage(img)
+                    }
+                } else {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(body)
+        flushText()
+
+        if segments.isEmpty {
+            // fallback for text not wrapped in block elements
+            let text = ((try? body.text()) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                segments.append(.text(text))
+            }
+        }
+        return segments
+    }
+
+    private static let blockTags: Set<String> = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "blockquote", "li"]
+
+    /// Resolve an image element's source to an archive path, ignoring external and data urls.
+    private static func imagePath(of element: Element, basePath: String) -> String? {
+        let src = [attr(element, "src"), attr(element, "xlink:href"), attr(element, "href")]
+            .compactMap { $0 }
+            .first
+        guard
+            let src,
+            !src.hasPrefix("data:"),
+            !src.hasPrefix("http://"), !src.hasPrefix("https://")
+        else { return nil }
+        return resolve(href: stripFragment(src), relativeTo: basePath)
+    }
+
+    /// Render an element's inline content, preserving emphasis as markdown.
+    private static func inlineMarkdown(of element: Element) -> String {
+        var result = ""
+        for node in element.getChildNodes() {
+            if let textNode = node as? TextNode {
+                result += textNode.text()
+            } else if let child = node as? Element {
+                let inner = inlineMarkdown(of: child)
+                switch localName(child) {
+                    case "em", "i":
+                        result += inner.isEmpty ? "" : "*\(inner)*"
+                    case "strong", "b":
+                        result += inner.isEmpty ? "" : "**\(inner)**"
+                    case "br":
+                        result += "\n"
+                    case "img":
+                        break // images are emitted as separate segments
+                    default:
+                        result += inner
+                }
+            }
+        }
+        return result
+    }
+
+    // MARK: - TOC
+
+    /// Chapter titles from an EPUB 3 nav document, keyed by archive path.
+    private static func navTitles(from archive: Archive, navPath: String) -> [String: String] {
+        guard
+            let html = extractString(from: archive, path: navPath),
+            let doc = try? SwiftSoup.parse(html)
+        else { return [:] }
+        let navDir = directory(of: navPath)
+
+        let navs = elements("nav", in: doc)
+        let toc = navs.first { attr($0, "epub:type") == "toc" } ?? navs.first
+        guard let toc else { return [:] }
+
+        var titles: [String: String] = [:]
+        for link in (try? toc.select("a[href]").array()) ?? [] {
+            guard
+                let href = attr(link, "href"),
+                let title = try? link.text(),
+                !title.isEmpty
+            else { continue }
+            let path = resolve(href: stripFragment(href), relativeTo: navDir)
+            if titles[path] == nil {
+                titles[path] = title
+            }
+        }
+        return titles
+    }
+
+    /// Chapter titles from an EPUB 2 NCX file, keyed by archive path.
+    private static func ncxTitles(from archive: Archive, ncxPath: String) -> [String: String] {
+        guard
+            let xml = extractString(from: archive, path: ncxPath),
+            let doc = try? SwiftSoup.parse(xml, "", Parser.xmlParser())
+        else { return [:] }
+        let ncxDir = directory(of: ncxPath)
+
+        var titles: [String: String] = [:]
+        for navPoint in elements("navpoint", in: doc) {
+            guard
+                let src = elements("content", in: navPoint).first.flatMap({ attr($0, "src") }),
+                let title = elements("navlabel", in: navPoint).first
+                    .flatMap({ elements("text", in: $0).first })
+                    .flatMap({ try? $0.text() }),
+                !title.isEmpty
+            else { continue }
+            let path = resolve(href: stripFragment(src), relativeTo: ncxDir)
+            if titles[path] == nil {
+                titles[path] = title
+            }
+        }
+        return titles
+    }
+
+    // MARK: - XML Helpers
+
+    /// The tag name without any namespace prefix, lowercased.
+    private static func localName(_ element: Element) -> String {
+        let tag = element.tagName().lowercased()
+        return tag.split(separator: ":").last.map(String.init) ?? tag
+    }
+
+    /// All descendant elements matching a local (namespace-stripped) tag name.
+    private static func elements(_ tag: String, in root: Element) -> [Element] {
+        (try? root.getAllElements().array())?.filter { $0 !== root && localName($0) == tag } ?? []
+    }
+
+    private static func elements(_ tag: String, in root: Document) -> [Element] {
+        (try? root.getAllElements().array())?.filter { localName($0) == tag } ?? []
+    }
+
+    /// A non-empty attribute value, or nil.
+    private static func attr(_ element: Element, _ name: String) -> String? {
+        guard let value = try? element.attr(name), !value.isEmpty else { return nil }
+        return value
+    }
+
+    // MARK: - Archive Helpers
+
+    /// Look up an archive entry, tolerating "./" prefixes, percent-encoding, and case differences.
+    static func entry(in archive: Archive, path: String) -> Entry? {
+        if let entry = archive[path] { return entry }
+        let target = path.lowercased()
+        return archive.first { entry in
+            var entryPath = entry.path
+            if entryPath.hasPrefix("./") {
+                entryPath = String(entryPath.dropFirst(2))
+            }
+            return entryPath.lowercased() == target
+                || (entryPath.removingPercentEncoding ?? entryPath).lowercased() == target
+        }
+    }
+
+    private static func extractData(from archive: Archive, path: String) -> Data? {
+        guard let entry = entry(in: archive, path: path) else { return nil }
+        var data = Data()
+        do {
+            _ = try archive.extract(entry) { data.append($0) }
+        } catch {
+            return nil
+        }
+        return data
+    }
+
+    private static func extractString(from archive: Archive, path: String) -> String? {
+        guard let data = extractData(from: archive, path: path) else { return nil }
+        return String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .utf16)
+            ?? String(data: data, encoding: .isoLatin1)
+    }
+
+    // MARK: - Path Helpers
+
+    private static func directory(of path: String) -> String {
+        path.split(separator: "/").dropLast().joined(separator: "/")
+    }
+
+    private static func stripFragment(_ href: String) -> String {
+        href.split(separator: "#", maxSplits: 1).first.map(String.init) ?? href
+    }
+
+    /// Resolve a (possibly percent-encoded) relative href against a base directory.
+    static func resolve(href: String, relativeTo dir: String) -> String {
+        let decoded = href.removingPercentEncoding ?? href
+        var components = dir.isEmpty ? [] : dir.split(separator: "/").map(String.init)
+        for part in decoded.split(separator: "/") {
+            switch part {
+                case ".":
+                    continue
+                case "..":
+                    if !components.isEmpty { components.removeLast() }
+                default:
+                    components.append(String(part))
+            }
+        }
+        return components.joined(separator: "/")
+    }
+}

--- a/Shared/Sources/Local/LocalFileDataManager.swift
+++ b/Shared/Sources/Local/LocalFileDataManager.swift
@@ -298,6 +298,7 @@ extension LocalFileDataManager {
         title: String,
         cover: String? = nil,
         description: String? = nil,
+        viewer: AidokuRunner.Viewer = .unknown,
         comicInfo: ComicInfo? = nil
     ) {
         let fileInfo = LocalFileInfoObject(context: context)
@@ -314,7 +315,8 @@ extension LocalFileDataManager {
                 key: id,
                 title: title,
                 cover: cover,
-                description: description
+                description: description,
+                viewer: viewer
             )
             var detailedManga = comicInfo.copy(into: basicManga)
             detailedManga.title = title
@@ -326,6 +328,13 @@ extension LocalFileDataManager {
             object.title = title
             object.cover = cover
             object.desc = description
+            object.viewer = switch viewer {
+                case .unknown: 0
+                case .rightToLeft: 1
+                case .leftToRight: 2
+                case .vertical: 3
+                case .webtoon: 4
+            }
         }
         object.fileInfo = fileInfo
 

--- a/Shared/Sources/Local/LocalFileDataManager.swift
+++ b/Shared/Sources/Local/LocalFileDataManager.swift
@@ -248,6 +248,22 @@ extension LocalFileDataManager {
 
         try? context.save()
 
+        // only report the file for removal if no other chapters still reference it
+        // (epub chapters share a single archive file)
+        if let filePath {
+            let request = ChapterObject.fetchRequest()
+            request.predicate = NSPredicate(
+                format: "mangaId == %@ AND sourceId == %@ AND fileInfo.path == %@",
+                mangaId,
+                LocalSourceRunner.sourceKey,
+                filePath
+            )
+            request.fetchLimit = 1
+            if let remaining = try? context.count(for: request), remaining > 0 {
+                return nil
+            }
+        }
+
         return filePath
     }
 

--- a/Shared/Sources/Local/LocalFileManager.swift
+++ b/Shared/Sources/Local/LocalFileManager.swift
@@ -21,7 +21,7 @@ actor LocalFileManager {
     private var lastScanTime = Date.distantPast
     private var scanTask: Task<Void, Never>?
 
-    static let allowedFileExtensions = Set(["cbz", "zip"])
+    static let allowedFileExtensions = Set(["cbz", "zip", "epub"])
     static let allowedImageExtensions = Set(["jpg", "jpeg", "png", "webp", "gif", "heic", "avif"])
     static let allowedTextExtensions = Set(["txt", "md"])
     static let allowedPageExtensions = allowedImageExtensions.union(allowedTextExtensions)
@@ -56,6 +56,25 @@ extension LocalFileManager {
         let pathExtension = url.pathExtension.lowercased()
         guard Self.allowedFileExtensions.contains(pathExtension) else {
             return nil
+        }
+
+        if pathExtension == "epub" {
+            guard let book = EpubParser.parse(url: url), !book.chapters.isEmpty else {
+                return nil
+            }
+            // carry epub metadata through the existing ComicInfo import path
+            var comicInfo = ComicInfo()
+            comicInfo.series = book.title
+            comicInfo.summary = book.description
+            comicInfo.writer = book.author
+            return ImportFileInfo(
+                url: url,
+                previewImages: book.coverData.flatMap { PlatformImage(data: $0) }.map { [$0] } ?? [],
+                name: url.lastPathComponent,
+                pageCount: book.chapters.count,
+                fileType: .epub,
+                comicInfo: comicInfo
+            )
         }
 
         // read zip file
@@ -131,7 +150,82 @@ extension LocalFileManager {
 
         let documentsDir = FileManager.default.documentDirectory
         let archiveURL = documentsDir.appendingPathComponent(cbzPath)
+        if archiveURL.pathExtension.lowercased() == "epub" {
+            return readEpubPages(from: archiveURL, chapterId: chapterId)
+        }
         return readPages(from: archiveURL)
+    }
+
+    // read the pages for an epub chapter
+    // the chapter id has the format "<epub file name>/<content file path>"
+    nonisolated func readEpubPages(from archiveURL: URL, chapterId: String) -> [AidokuRunner.Page] {
+        let prefix = archiveURL.lastPathComponent + "/"
+        let href = chapterId.hasPrefix(prefix) ? String(chapterId.dropFirst(prefix.count)) : chapterId
+        let segments = EpubParser.chapterSegments(url: archiveURL, href: href)
+        guard !segments.isEmpty else {
+            LogManager.logger.error("Failed to read epub chapter \(chapterId) from \(archiveURL.lastPathComponent)")
+            return []
+        }
+
+        let hasText = segments.contains {
+            if case .text = $0 { return true }
+            return false
+        }
+
+        if hasText {
+            // build a single markdown page with inline image references so the
+            // whole chapter stays in the text reader
+            let parts: [String] = segments.compactMap { segment in
+                switch segment {
+                    case .text(let text):
+                        return text
+                    case .image(let path):
+                        guard let cachedURL = Self.cacheEpubImage(archiveURL: archiveURL, path: path) else {
+                            return nil
+                        }
+                        return "![image](\(cachedURL.absoluteString))"
+                }
+            }
+            return [AidokuRunner.Page(content: .text(parts.joined(separator: "\n\n")))]
+        }
+
+        // image-only chapter (cover, illustration pages)
+        return segments.compactMap { segment in
+            guard case let .image(path) = segment else { return nil }
+            return AidokuRunner.Page(content: .zipFile(url: archiveURL, filePath: path))
+        }
+    }
+
+    // extract an image from an epub archive into the cache directory so it can
+    // be referenced with a file url from markdown text
+    nonisolated static func cacheEpubImage(archiveURL: URL, path: String) -> URL? {
+        guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        else { return nil }
+
+        // stable per-book folder name (fnv-1a hash of the archive path)
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in archiveURL.path.utf8 {
+            hash = (hash ^ UInt64(byte)) &* 0x100000001b3
+        }
+        let bookDir = cachesDir
+            .appendingPathComponent("EpubImages", isDirectory: true)
+            .appendingPathComponent(String(hash, radix: 16), isDirectory: true)
+        let fileURL = bookDir.appendingPathComponent(path.replacingOccurrences(of: "/", with: "_"))
+
+        if fileURL.exists {
+            return fileURL
+        }
+
+        bookDir.createDirectory()
+        do {
+            let archive = try Archive(url: archiveURL, accessMode: .read)
+            guard let entry = EpubParser.entry(in: archive, path: path) else { return nil }
+            _ = try archive.extract(entry, to: fileURL)
+            return fileURL
+        } catch {
+            LogManager.logger.error("Failed to extract epub image \(path): \(error)")
+            return nil
+        }
     }
 
     // read pages from an archive file
@@ -259,6 +353,19 @@ extension LocalFileManager {
             if shouldRemoveUrl {
                 try? FileManager.default.removeItem(at: url)
             }
+        }
+
+        // epub files create a chapter per spine item instead of image pages
+        if url.pathExtension.lowercased() == "epub" {
+            try await uploadEpub(
+                from: url,
+                skipUpload: skipUpload,
+                mangaId: mangaId,
+                mangaCoverImage: mangaCoverImage,
+                mangaName: mangaName,
+                mangaDescription: mangaDescription
+            )
+            return
         }
 
         // read zip file
@@ -438,6 +545,105 @@ extension LocalFileManager {
             chapter: chapter,
             comicInfo: comicInfo
         )
+    }
+
+    // add an epub file to the local files source, creating a chapter per spine item
+    // swiftlint:disable:next function_parameter_count
+    private func uploadEpub(
+        from url: URL,
+        skipUpload: Bool,
+        mangaId: String?,
+        mangaCoverImage: PlatformImage?,
+        mangaName: String?,
+        mangaDescription: String?
+    ) async throws(LocalFileManagerError) {
+        guard let book = EpubParser.parse(url: url) else {
+            throw LocalFileManagerError.cannotReadArchive
+        }
+        guard !book.chapters.isEmpty else {
+            throw LocalFileManagerError.noImagesFound
+        }
+
+        let resolvedMangaId = (mangaId ?? mangaName ?? book.title ?? url.deletingPathExtension().lastPathComponent).normalized
+        let mangaTitle = mangaName ?? book.title ?? resolvedMangaId
+
+        // create new folder for the manga
+        let fileManager = FileManager.default
+        let localFolder = fileManager.documentDirectory.appendingPathComponent("Local", isDirectory: true)
+        localFolder.createDirectory()
+        let mangaFolder = localFolder.appendingPathComponent(resolvedMangaId, isDirectory: true)
+        mangaFolder.createDirectory()
+
+        // copy file to Documents/Local/<mangaId>/<epubfile>
+        let destURL: URL
+        if skipUpload {
+            destURL = url
+        } else {
+            var newDestURL = mangaFolder.appendingPathComponent(url.lastPathComponent)
+            var counter = 1
+            while newDestURL.exists {
+                let name = url.lastPathComponent.removingExtension() + " (\(counter)).\(url.pathExtension)"
+                newDestURL = mangaFolder.appendingPathComponent(name)
+                counter += 1
+            }
+            destURL = newDestURL
+            do {
+                try fileManager.copyItem(at: url, to: destURL)
+            } catch {
+                throw LocalFileManagerError.fileCopyFailed
+            }
+        }
+
+        // save provided cover image, or fall back to the embedded epub cover
+        var coverURL: URL?
+        let coverImage = mangaCoverImage ?? book.coverData.flatMap { PlatformImage(data: $0) }
+        if mangaCoverImage != nil || mangaId == nil, let coverImage {
+            let newCoverURL = mangaFolder.appendingPathComponent("cover.png")
+            do {
+                if newCoverURL.exists {
+                    try fileManager.removeItem(at: newCoverURL)
+                }
+                try coverImage.pngData()?.write(to: newCoverURL)
+                coverURL = newCoverURL
+            } catch {
+                throw LocalFileManagerError.fileCopyFailed
+            }
+        }
+
+        // create the manga object in db if it doesn't exist yet
+        let hasMangaObject = if let mangaId {
+            await LocalFileDataManager.shared.hasSeries(id: mangaId)
+        } else {
+            false
+        }
+        if !hasMangaObject {
+            // carry epub metadata (author) through the ComicInfo path
+            var comicInfo = ComicInfo()
+            comicInfo.writer = book.author
+            await LocalFileDataManager.shared.createManga(
+                url: mangaFolder,
+                id: resolvedMangaId,
+                title: mangaTitle,
+                cover: coverURL?.toAidokuImageUrl()?.absoluteString,
+                description: mangaDescription ?? book.description,
+                // books read left to right, unlike the rtl manga default
+                viewer: .leftToRight,
+                comicInfo: comicInfo
+            )
+        }
+
+        // create a chapter for each spine item
+        // the chapter id encodes the content file path so pages can be fetched later
+        let fileName = destURL.lastPathComponent
+        for (index, chapter) in book.chapters.enumerated() {
+            await LocalFileDataManager.shared.createChapter(
+                mangaId: resolvedMangaId,
+                url: destURL,
+                id: "\(fileName)/\(chapter.href)",
+                title: chapter.title,
+                chapter: Float(index + 1)
+            )
+        }
     }
 }
 

--- a/Shared/Sources/Local/LocalFileManager.swift
+++ b/Shared/Sources/Local/LocalFileManager.swift
@@ -196,20 +196,29 @@ extension LocalFileManager {
         }
     }
 
-    // extract an image from an epub archive into the cache directory so it can
-    // be referenced with a file url from markdown text
-    nonisolated static func cacheEpubImage(archiveURL: URL, path: String) -> URL? {
+    // cache directory for extracted images of a given epub archive
+    nonisolated static func epubImageCacheDirectory(for archiveURL: URL) -> URL? {
         guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
         else { return nil }
 
-        // stable per-book folder name (fnv-1a hash of the archive path)
-        var hash: UInt64 = 0xcbf29ce484222325
-        for byte in archiveURL.path.utf8 {
-            hash = (hash ^ UInt64(byte)) &* 0x100000001b3
+        // stable per-book folder name (fnv-1a hash)
+        func hash(_ string: String) -> String {
+            var hash: UInt64 = 0xcbf29ce484222325
+            for byte in string.utf8 {
+                hash = (hash ^ UInt64(byte)) &* 0x100000001b3
+            }
+            return String(hash, radix: 16)
         }
-        let bookDir = cachesDir
+
+        return cachesDir
             .appendingPathComponent("EpubImages", isDirectory: true)
-            .appendingPathComponent(String(hash, radix: 16), isDirectory: true)
+            .appendingPathComponent(hash(archiveURL.path), isDirectory: true)
+    }
+
+    // extract an image from an epub archive into the cache directory so it can
+    // be referenced with a file url from markdown text
+    nonisolated static func cacheEpubImage(archiveURL: URL, path: String) -> URL? {
+        guard let bookDir = epubImageCacheDirectory(for: archiveURL) else { return nil }
         let fileURL = bookDir.appendingPathComponent(path.replacingOccurrences(of: "/", with: "_"))
 
         if fileURL.exists {
@@ -698,6 +707,7 @@ extension LocalFileManager {
         if fileURL.exists {
             try? FileManager.default.removeItem(at: fileURL)
         }
+        Self.removeEpubImageCache(for: fileURL)
     }
 
     // remove a chapter from a given local manga
@@ -715,6 +725,15 @@ extension LocalFileManager {
         if fileURL.exists {
             try? FileManager.default.removeItem(at: fileURL)
         }
+        Self.removeEpubImageCache(for: fileURL)
+    }
+
+    // remove cached extracted images for a given epub archive
+    nonisolated static func removeEpubImageCache(for archiveURL: URL) {
+        guard archiveURL.pathExtension.lowercased() == "epub",
+              let bookDir = epubImageCacheDirectory(for: archiveURL)
+        else { return }
+        try? FileManager.default.removeItem(at: bookDir)
     }
 
     // remove all local source files and db objects
@@ -729,6 +748,11 @@ extension LocalFileManager {
             try fileManager.removeItem(at: localFolder)
         } catch {
             LogManager.logger.error("Failed to remove Local folder: \(error)")
+        }
+
+        // clear extracted epub images
+        if let cachesDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            try? fileManager.removeItem(at: cachesDir.appendingPathComponent("EpubImages", isDirectory: true))
         }
 
         // update database

--- a/Shared/Sources/Local/LocalFileManager.swift
+++ b/Shared/Sources/Local/LocalFileManager.swift
@@ -714,18 +714,24 @@ extension LocalFileManager {
     func removeChapter(mangaId: String, chapterId: String) async {
         // remove from db
         let filePath = await LocalFileDataManager.shared.removeChapter(mangaId: mangaId, chapterId: chapterId)
-        guard let filePath else { return }
 
-        // disable file listener while we make changes to the disk
-        self.suppressFileEvents = true
-        defer { self.suppressFileEvents = false }
+        if let filePath {
+            // disable file listener while we make changes to the disk
+            self.suppressFileEvents = true
+            defer { self.suppressFileEvents = false }
 
-        let documentsDir = FileManager.default.documentDirectory
-        let fileURL = documentsDir.append(path: filePath)
-        if fileURL.exists {
-            try? FileManager.default.removeItem(at: fileURL)
+            let documentsDir = FileManager.default.documentDirectory
+            let fileURL = documentsDir.append(path: filePath)
+            if fileURL.exists {
+                try? FileManager.default.removeItem(at: fileURL)
+            }
+            Self.removeEpubImageCache(for: fileURL)
         }
-        Self.removeEpubImageCache(for: fileURL)
+
+        // remove the manga entry once no chapters remain
+        if await LocalFileDataManager.shared.fetchChapters(mangaId: mangaId).isEmpty {
+            await removeManga(with: mangaId)
+        }
     }
 
     // remove cached extracted images for a given epub archive

--- a/Shared/Sources/Local/LocalModels.swift
+++ b/Shared/Sources/Local/LocalModels.swift
@@ -24,11 +24,13 @@ struct LocalSeriesInfo: Hashable {
 enum LocalFileType {
     case cbz
     case zip
+    case epub
 
     var localizedName: String {
         switch self {
             case .cbz: NSLocalizedString("CBZ_NAME")
             case .zip: NSLocalizedString("ZIP_NAME")
+            case .epub: NSLocalizedString("EPUB_NAME")
         }
     }
 }

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -605,7 +605,7 @@ extension AppDelegate {
             }
         } else if
             SourceManager.shared.localSourceInstalled
-                && (url.pathExtension == "cbz" || url.pathExtension == "zip")
+                && LocalFileManager.allowedFileExtensions.contains(url.pathExtension.lowercased())
         {
             Task {
                 let fileInfo = await LocalFileManager.shared.loadImportFileInfo(url: url)

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -50,6 +50,16 @@
 				<string>vnd.comicbook-rar</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Electronic Publication (EPUB)</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.idpf.epub-container</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/iOS/New/Views/Browse/LocalFileImportView.swift
+++ b/iOS/New/Views/Browse/LocalFileImportView.swift
@@ -134,7 +134,7 @@ extension LocalFileImportView.ContentView {
             }
             .sheet(isPresented: $importing) {
                 DocumentPickerView(
-                    allowedContentTypes: [.init(filenameExtension: "cbz")!, .zip],
+                    allowedContentTypes: [.init(filenameExtension: "cbz")!, .zip, .epub],
                     onDocumentsPicked: { urls in
                         guard let url = urls.first else {
                             loadingImport = false
@@ -236,7 +236,13 @@ extension LocalFileImportView.ContentView {
                     .lineLimit(4)
                     .padding(.horizontal, 20)
                 Text({
-                    let pagesText = if fileInfo.pageCount == 1 {
+                    let pagesText = if fileInfo.fileType == .epub {
+                        if fileInfo.pageCount == 1 {
+                            NSLocalizedString("1_CHAPTER")
+                        } else {
+                            String(format: NSLocalizedString("%i_CHAPTERS"), fileInfo.pageCount)
+                        }
+                    } else if fileInfo.pageCount == 1 {
                         NSLocalizedString("1_PAGE")
                     } else {
                         String(format: NSLocalizedString("%i_PAGES"), fileInfo.pageCount)
@@ -253,64 +259,67 @@ extension LocalFileImportView.ContentView {
 
             // fields
             VStack(spacing: interItemSpacing) {
-                // name
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(NSLocalizedString("CHAPTER_TITLE")).fontWeight(.medium)
+                // chapter fields don't apply to epubs, whose chapters come from the file itself
+                if fileInfo.fileType != .epub {
+                    // name
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(NSLocalizedString("CHAPTER_TITLE")).fontWeight(.medium)
 
-                    TextFieldWrapper {
-                        TextField(NSLocalizedString("CHAPTER_TITLE"), text: $name)
-                            .autocorrectionDisabled()
-                        if !name.isEmpty {
-                            ClearFieldButton {
-                                name = ""
-                            }
-                        }
-                    }
-                }
-
-                // volume/chapter
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: interItemSpacing) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(NSLocalizedString("VOLUME")).fontWeight(.medium)
-
-                            TextFieldWrapper(hasError: !volumeChapterValid || volumeChapterEmpty) {
-                                TextField(NSLocalizedString("VOLUME"), value: $volume, format: .number)
-                                    .keyboardType(.decimalPad)
-                                if volume != nil {
-                                    ClearFieldButton {
-                                        volume = nil
-                                    }
-                                }
-                            }
-                        }
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(NSLocalizedString("CHAPTER")).fontWeight(.medium)
-
-                            TextFieldWrapper(hasError: !volumeChapterValid || volumeChapterEmpty) {
-                                TextField(NSLocalizedString("CHAPTER"), value: $chapter, format: .number)
-                                    .keyboardType(.decimalPad)
-                                if chapter != nil {
-                                    ClearFieldButton {
-                                        chapter = nil
-                                    }
+                        TextFieldWrapper {
+                            TextField(NSLocalizedString("CHAPTER_TITLE"), text: $name)
+                                .autocorrectionDisabled()
+                            if !name.isEmpty {
+                                ClearFieldButton {
+                                    name = ""
                                 }
                             }
                         }
                     }
 
-                    if !volumeChapterValid {
-                        fieldTextView(NSLocalizedString("VOLUME_CHAPTER_INVALID_ERROR"), error: true)
-                    } else if volumeChapterEmpty {
-                        fieldTextView(NSLocalizedString("VOLUME_CHAPTER_EMPTY_ERROR"), error: true)
+                    // volume/chapter
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: interItemSpacing) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(NSLocalizedString("VOLUME")).fontWeight(.medium)
+
+                                TextFieldWrapper(hasError: !volumeChapterValid || volumeChapterEmpty) {
+                                    TextField(NSLocalizedString("VOLUME"), value: $volume, format: .number)
+                                        .keyboardType(.decimalPad)
+                                    if volume != nil {
+                                        ClearFieldButton {
+                                            volume = nil
+                                        }
+                                    }
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(NSLocalizedString("CHAPTER")).fontWeight(.medium)
+
+                                TextFieldWrapper(hasError: !volumeChapterValid || volumeChapterEmpty) {
+                                    TextField(NSLocalizedString("CHAPTER"), value: $chapter, format: .number)
+                                        .keyboardType(.decimalPad)
+                                    if chapter != nil {
+                                        ClearFieldButton {
+                                            chapter = nil
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if !volumeChapterValid {
+                            fieldTextView(NSLocalizedString("VOLUME_CHAPTER_INVALID_ERROR"), error: true)
+                        } else if volumeChapterEmpty {
+                            fieldTextView(NSLocalizedString("VOLUME_CHAPTER_EMPTY_ERROR"), error: true)
+                        }
                     }
-                }
-                .onChange(of: volume) { _ in
-                    validateVolumeChapter()
-                }
-                .onChange(of: chapter) { _ in
-                    validateVolumeChapter()
+                    .onChange(of: volume) { _ in
+                        validateVolumeChapter()
+                    }
+                    .onChange(of: chapter) { _ in
+                        validateVolumeChapter()
+                    }
                 }
 
                 // series select

--- a/iOS/UI/Reader/Page/MarkdownView.swift
+++ b/iOS/UI/Reader/Page/MarkdownView.swift
@@ -37,6 +37,7 @@ struct MarkdownView: View {
         Markdown {
             markdownString
         }
+        .markdownImageProvider(LocalFileImageProvider())
         .markdownTextStyle {
             FontFamily(.custom(fontFamily == "System" ? ".AppleSystemUIFont" : fontFamily))
             FontSize(fontSize)
@@ -60,6 +61,21 @@ struct MarkdownView: View {
         .fullScreenCover(isPresented: $showSafari) {
             SafariView(url: $safariUrl)
                 .ignoresSafeArea()
+        }
+    }
+}
+
+/// Loads file urls (e.g. images extracted from epubs) directly from disk,
+/// since the default provider only handles network urls.
+private struct LocalFileImageProvider: ImageProvider {
+    @ViewBuilder
+    func makeImage(url: URL?) -> some View {
+        if let url, url.isFileURL, let image = UIImage(contentsOfFile: url.path) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        } else {
+            DefaultImageProvider.default.makeImage(url: url)
         }
     }
 }

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -627,13 +627,20 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
     func loadPreviousChapter() {
         guard let previousChapter else { return }
         Task {
-            // Preload and verify the chapter has text pages before switching.
-            // Non-text chapters would require a reading-mode change that the
-            // paged text reader can't handle — snap back to the transition page.
+            // Preload to check whether the chapter has text pages.
             await viewModel.preload(chapter: previousChapter)
             let preloaded = viewModel.preloadedPages
-            guard !preloaded.isEmpty, preloaded.allSatisfy({ $0.isTextPage }) else {
+            guard !preloaded.isEmpty else {
                 await MainActor.run { snapBackToTransitionPage() }
+                return
+            }
+            guard preloaded.allSatisfy({ $0.isTextPage }) else {
+                // Non-text chapter: hand off to the parent controller, which
+                // switches to the appropriate reader and reloads the chapter.
+                await MainActor.run {
+                    delegate?.setChapter(previousChapter)
+                    delegate?.setPages(preloaded)
+                }
                 return
             }
             delegate?.setChapter(previousChapter)
@@ -646,8 +653,17 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
         Task {
             await viewModel.preload(chapter: nextChapter)
             let preloaded = viewModel.preloadedPages
-            guard !preloaded.isEmpty, preloaded.allSatisfy({ $0.isTextPage }) else {
+            guard !preloaded.isEmpty else {
                 await MainActor.run { snapBackToTransitionPage() }
+                return
+            }
+            guard preloaded.allSatisfy({ $0.isTextPage }) else {
+                // Non-text chapter: hand off to the parent controller, which
+                // switches to the appropriate reader and reloads the chapter.
+                await MainActor.run {
+                    delegate?.setChapter(nextChapter)
+                    delegate?.setPages(preloaded)
+                }
                 return
             }
             delegate?.setChapter(nextChapter)

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -362,7 +362,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
             return
         }
 
-        let targetIndex = min(max(0, index), pages.count - 1)
+        let targetIndex = alignedPageIndex(min(max(0, index), pages.count - 1))
 
         let oldIndex = currentPageIndex
         currentPageIndex = targetIndex
@@ -396,7 +396,15 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         updateSliderPosition()
     }
 
+    /// Snap an index to the left page of its double-page spread so spreads always
+    /// pair (0,1), (2,3), … — otherwise stepping by 2 skips the first/last page
+    /// when navigation lands on an odd index (slider, history restore, chapter end).
+    private func alignedPageIndex(_ index: Int) -> Int {
+        usesDoublePages ? index - (index % 2) : index
+    }
+
     private func createPageViewController(for index: Int) -> UIViewController {
+        let index = alignedPageIndex(index)
 
         guard index >= 0 && index < pages.count else {
             // Return empty view controller as fallback

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -392,7 +392,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         }
 
         // Update current page display (1-indexed for UI)
-        delegate?.setCurrentPage(targetIndex + 1, position: normalizedPosition(for: targetIndex))
+        reportCurrentPage(for: targetIndex)
         updateSliderPosition()
     }
 
@@ -401,6 +401,15 @@ class ReaderPagedTextViewController: BaseObservingViewController {
     /// when navigation lands on an odd index (slider, history restore, chapter end).
     private func alignedPageIndex(_ index: Int) -> Int {
         usesDoublePages ? index - (index % 2) : index
+    }
+
+    /// Report the rightmost visible page of the spread at the given aligned index.
+    /// The delegate marks the chapter completed when the reported page reaches the
+    /// total page count, so the right page of the final spread must be reported —
+    /// not just the (left) spread index.
+    private func reportCurrentPage(for index: Int) {
+        let visibleIndex = usesDoublePages ? min(index + 1, pages.count - 1) : index
+        delegate?.setCurrentPage(visibleIndex + 1, position: normalizedPosition(for: visibleIndex))
     }
 
     private func createPageViewController(for index: Int) -> UIViewController {
@@ -715,7 +724,7 @@ extension ReaderPagedTextViewController: UIPageViewControllerDelegate {
             currentCharacterOffset = doublePage.leftPage.range.location
         }
 
-        delegate?.setCurrentPage(currentPageIndex + 1, position: normalizedPosition(for: currentPageIndex))
+        reportCurrentPage(for: currentPageIndex)
         updateSliderPosition()
     }
 

--- a/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
@@ -122,6 +122,15 @@ class TextPaginator {
                 result.append(NSAttributedString(string: "\n", attributes: config.attributes))
             }
 
+            // Render inline images (e.g. epub illustrations) as text attachments
+            if let imageURL = run.imageURL {
+                if let attachmentString = imageAttachmentString(for: imageURL) {
+                    result.append(attachmentString)
+                }
+                lastBlockIdentity = currentIdentity
+                continue
+            }
+
             // Determine block-level attributes
             var runAttrs = config.attributes
             if let intent = blockIntent {
@@ -149,6 +158,36 @@ class TextPaginator {
             lastBlockIdentity = currentIdentity
         }
 
+        return result
+    }
+
+    /// Build a centered text attachment for an image, scaled to fit the page
+    /// content area so pagination never produces an unfillable page.
+    private func imageAttachmentString(for url: URL) -> NSAttributedString? {
+        guard url.isFileURL, let image = UIImage(contentsOfFile: url.path) else {
+            return nil
+        }
+
+        let content = contentSize(for: pageSize)
+        let maxWidth = content.width > 50 ? content.width : 300
+        let maxHeight = content.height > 50 ? content.height * 0.95 : 400
+        let scale = min(1, maxWidth / max(1, image.size.width), maxHeight / max(1, image.size.height))
+
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        attachment.bounds = CGRect(
+            x: 0,
+            y: 0,
+            width: image.size.width * scale,
+            height: image.size.height * scale
+        )
+
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
+        style.paragraphSpacing = config.paragraphSpacing
+
+        let result = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+        result.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: result.length))
         return result
     }
 

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
@@ -561,9 +561,13 @@ extension ReaderTextViewController {
                 return
             }
 
-            // Don't infinite-scroll into non-text chapters — the reading mode
-            // would switch abruptly. The boundary transition view stays visible.
+            // Non-text chapter: hand off to the parent controller, which
+            // switches to the appropriate reader and reloads the chapter.
             guard newPages.allSatisfy({ $0.isTextPage }) else {
+                await MainActor.run {
+                    delegate?.setChapter(nextCh)
+                    delegate?.setPages(newPages)
+                }
                 loadingNext = false
                 return
             }
@@ -630,8 +634,13 @@ extension ReaderTextViewController {
                 return
             }
 
-            // Don't infinite-scroll into non-text chapters
+            // Non-text chapter: hand off to the parent controller, which
+            // switches to the appropriate reader and reloads the chapter.
             guard newPages.allSatisfy({ $0.isTextPage }) else {
+                await MainActor.run {
+                    delegate?.setChapter(prevCh)
+                    delegate?.setPages(newPages)
+                }
                 loadingPrevious = false
                 return
             }


### PR DESCRIPTION
## Summary

Adds EPUB support to the local source. EPUB files can now be imported and read with the existing text readers (paged and scroll), including inline images.

Closes #609 

## How it works

- **Import:** One EPUB file = one series. `EpubParser` reads the OPF spine and groups spine files into logical chapters based on the TOC (`toc.ncx` / nav document), so multi-file chapters appear as a single chapter entry.
- **Chapter IDs** use the format `<epub file name>/<primary href>`, decoded in `LocalFileManager.readEpubPages`.
- **Text chapters** are converted into a single markdown `.text` page with inline `![image](file://…)` references; images are extracted to `Caches/EpubImages/`.
- **Image-only chapters** (cover pages, illustration galleries) are kept as `.zipFile` pages and open in the regular image reader.
- Small decorative images (<100 KB, e.g. chapter ornaments) stay inline in text chapters instead of forcing the chapter into the image reader.

## Reader changes

- `TextPaginator` renders inline images via `NSTextAttachment`, capped to the content size so oversized images can't swallow the remaining page text.
- `MarkdownView` (scroll reader) gets a `LocalFileImageProvider`, since MarkdownUI's default provider ignores `file://` URLs.

## Also included

- fix(textreader): align double-page spreads to even page indices
- fix(textreader): `alignedPageIndex` never reported a finished chapter

## Testing

- Imported EPUBs (incl. J-Novel Club light novels with per-heading ornament images and illustration inserts) and verified chapter grouping, inline images, and progress tracking in both paged and scroll text readers.