### PR TITLE
feat(epub): add epub reading functionality to komga and kavita

### DIFF
--- a/Shared/Sources/Kavita/KavitaHelper.swift
+++ b/Shared/Sources/Kavita/KavitaHelper.swift
@@ -167,6 +167,37 @@ struct KavitaHelper: Sendable {
         }
     }
 
+    // Fetch a raw string response (e.g. epub chapter html).
+    func requestString(path: String) async throws(SourceError) -> String {
+        let url = try getServerUrl(path: path)
+
+        func doRequest() async throws(SourceError) -> String? {
+            var request = URLRequest(url: url)
+            guard authorize(request: &request) else {
+                throw SourceError.message("NOT_LOGGED_IN")
+            }
+            guard
+                let result = try? await URLSession.shared.data(for: request),
+                let response = result.1 as? HTTPURLResponse
+            else {
+                throw SourceError.networkError
+            }
+            if response.statusCode == 401 {
+                return nil
+            }
+            return String(data: result.0, encoding: .utf8)
+        }
+
+        if let result = try await doRequest() {
+            return result
+        }
+        // retry after re-auth
+        guard try await refreshToken(), let result = try await doRequest() else {
+            throw SourceError.message("NOT_LOGGED_IN")
+        }
+        return result
+    }
+
     func refreshToken() async throws(SourceError) -> Bool {
         let url = try getServerUrl(path: "api/account/refresh-token")
 

--- a/Shared/Sources/Kavita/KavitaHelper.swift
+++ b/Shared/Sources/Kavita/KavitaHelper.swift
@@ -61,6 +61,53 @@ struct KavitaHelper: Sendable {
         body: Data? = nil,
         lastWorkingMirror: inout URL?
     ) async throws(SourceError) -> T {
+        let data = try await requestData(path: path, method: method, body: body, lastWorkingMirror: &lastWorkingMirror)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom({ decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            let formatter = DateFormatter()
+            formatter.timeZone = if #available(iOS 16.0, macOS 13.0, *) {
+                .gmt
+            } else {
+                .init(secondsFromGMT: 0)
+            }
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS"
+            var date = formatter.date(from: string)
+            if date == nil {
+                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+                date = formatter.date(from: string)
+            }
+            return date ?? .distantPast
+        })
+        if let result = try? decoder.decode(T.self, from: data) {
+            return result
+        } else if let error = try? decoder.decode(KavitaErrorResponse.self, from: data) {
+            throw SourceError.message(error.title)
+        } else {
+            throw SourceError.message("UNKNOWN_ERROR")
+        }
+    }
+
+    // Fetch a raw string response (e.g. epub chapter html).
+    func requestString(path: String) async throws(SourceError) -> String {
+        var dummy: URL?
+        let data = try await requestData(path: path, accept: nil, lastWorkingMirror: &dummy)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw SourceError.message("UNKNOWN_ERROR")
+        }
+        return string
+    }
+
+    // Fetch raw response data, handling mirrors and re-authentication.
+    func requestData(
+        path: String,
+        method: HttpMethod = .GET,
+        body: Data? = nil,
+        accept: String? = "application/json",
+        lastWorkingMirror: inout URL?
+    ) async throws(SourceError) -> Data {
         let mainUrl = try getConfiguredServer()
         let mirrors = getMirrors()
         var allBaseUrls: [URL] = []
@@ -80,7 +127,7 @@ struct KavitaHelper: Sendable {
             URLSession.shared
         }
 
-        func doRequest(baseUrl: URL) async throws(SourceError) -> T? {
+        func doRequest(baseUrl: URL) async throws(SourceError) -> Data? {
             guard let url = URL(string: path, relativeTo: baseUrl) else {
                 throw SourceError.message("INVALID_SERVER_URL")
             }
@@ -88,7 +135,9 @@ struct KavitaHelper: Sendable {
             guard authorize(request: &request) else {
                 throw SourceError.message("NOT_LOGGED_IN")
             }
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            if let accept {
+                request.setValue(accept, forHTTPHeaderField: "Accept")
+            }
             request.httpMethod = method.stringValue
             if let body {
                 request.httpBody = body
@@ -105,35 +154,10 @@ struct KavitaHelper: Sendable {
             if response.statusCode == 401 {
                 return nil
             }
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .custom({ decoder in
-                let container = try decoder.singleValueContainer()
-                let string = try container.decode(String.self)
-                let formatter = DateFormatter()
-                formatter.timeZone = if #available(iOS 16.0, macOS 13.0, *) {
-                    .gmt
-                } else {
-                    .init(secondsFromGMT: 0)
-                }
-                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS"
-                var date = formatter.date(from: string)
-                if date == nil {
-                    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-                    date = formatter.date(from: string)
-                }
-                return date ?? .distantPast
-            })
-            if let result = try? decoder.decode(T.self, from: data) as T? {
-                return result
-            } else if let error = try? decoder.decode(KavitaErrorResponse.self, from: data) {
-                throw SourceError.message(error.title)
-            } else {
-                throw SourceError.message("UNKNOWN_ERROR")
-            }
+            return data
         }
 
-        func tryRequests(ignoreFinalError: Bool = false) async throws(SourceError) -> T? {
+        func tryRequests(ignoreFinalError: Bool = false) async throws(SourceError) -> Data? {
             for (idx, baseUrl) in allBaseUrls.enumerated() {
                 do {
                     if let result = try await doRequest(baseUrl: baseUrl) {
@@ -165,37 +189,6 @@ struct KavitaHelper: Sendable {
             }
             return result
         }
-    }
-
-    // Fetch a raw string response (e.g. epub chapter html).
-    func requestString(path: String) async throws(SourceError) -> String {
-        let url = try getServerUrl(path: path)
-
-        func doRequest() async throws(SourceError) -> String? {
-            var request = URLRequest(url: url)
-            guard authorize(request: &request) else {
-                throw SourceError.message("NOT_LOGGED_IN")
-            }
-            guard
-                let result = try? await URLSession.shared.data(for: request),
-                let response = result.1 as? HTTPURLResponse
-            else {
-                throw SourceError.networkError
-            }
-            if response.statusCode == 401 {
-                return nil
-            }
-            return String(data: result.0, encoding: .utf8)
-        }
-
-        if let result = try await doRequest() {
-            return result
-        }
-        // retry after re-auth
-        guard try await refreshToken(), let result = try await doRequest() else {
-            throw SourceError.message("NOT_LOGGED_IN")
-        }
-        return result
     }
 
     func refreshToken() async throws(SourceError) -> Bool {

--- a/Shared/Sources/Kavita/KavitaModels.swift
+++ b/Shared/Sources/Kavita/KavitaModels.swift
@@ -237,33 +237,107 @@ struct KavitaVolume: Codable, Sendable {
         let pagesRead: Int
         let lastReadingProgressUtc: Date
         let files: [File]
+
+        var isEpub: Bool {
+            files.contains { $0.format == 3 }
+        }
     }
 
     let id: Int
     let name: String
     let number: Int
+    let minNumber: Float?
     let seriesId: Int
     let chapters: [Chapter]
+
+    /// The volume number; the legacy `number` field truncates fractional
+    /// volumes (e.g. 9.5 -> 9), so prefer `minNumber` where available.
+    var resolvedNumber: Float {
+        minNumber ?? Float(number)
+    }
+}
+
+/// An entry of an epub's table of contents, from `api/book/{chapterId}/chapters`.
+struct KavitaBookChapterItem: Codable, Sendable {
+    let title: String
+    let page: Int
+    let children: [KavitaBookChapterItem]?
 }
 
 extension KavitaVolume {
-    func intoChapters(baseUrl: URL, apiKey: String) -> [AidokuRunner.Chapter] {
-        chapters.compactMap { chapter -> AidokuRunner.Chapter? in
-            let isEpub = chapter.files.contains(where: { $0.format == 3 })
-            guard !isEpub else { return nil }
+    /// `epubTocs` maps epub chapter ids to their table of contents; epub
+    /// chapters without an entry are dropped (their toc failed to load).
+    func intoChapters(baseUrl: URL, apiKey: String, epubTocs: [Int: [KavitaBookChapterItem]] = [:]) -> [AidokuRunner.Chapter] {
+        chapters.flatMap { chapter -> [AidokuRunner.Chapter] in
+            if chapter.isEpub {
+                guard let toc = epubTocs[chapter.id] else { return [] }
+                return chapter.intoEpubChapters(volume: self, toc: toc, baseUrl: baseUrl, apiKey: apiKey)
+            }
             let chapterNumber = Float(chapter.number) ?? 0
-            let noVolume = number < 0 || number >= 100000
+            let noVolume = resolvedNumber < 0 || resolvedNumber >= 100000
             let noChapter = chapterNumber < 0 || chapterNumber >= 100000
-            return .init(
+            return [.init(
                 key: "\(chapter.id)",
                 title: (chapter.titleName?.isEmpty ?? true) ? nil : chapter.titleName,
                 chapterNumber: noChapter ? nil : chapterNumber,
-                volumeNumber: noVolume ? nil : Float(number),
+                volumeNumber: noVolume ? nil : resolvedNumber,
                 dateUploaded: chapter.createdUtc,
                 url: URL(string: "library/1/series/\(seriesId)/chapter/\(chapter.id)", relativeTo: baseUrl),
                 language: chapter.language,
                 thumbnail: URL(
                     string: "api/image/chapter-cover?chapterId=\(chapter.id)&apiKey=\(apiKey)",
+                    relativeTo: baseUrl
+                )?.absoluteString
+            )]
+        }
+    }
+}
+
+extension KavitaVolume.Chapter {
+    /// Chapters for an epub, one per logical epub chapter, grouping the spine
+    /// pages by their toc titles like local epubs. The chapter key has the
+    /// format "<kavita chapter id>/<first spine page>-<end spine page>".
+    func intoEpubChapters(
+        volume: KavitaVolume,
+        toc: [KavitaBookChapterItem],
+        baseUrl: URL,
+        apiKey: String
+    ) -> [AidokuRunner.Chapter] {
+        // first toc title per spine page
+        var titles: [Int: String] = [:]
+        func walk(_ items: [KavitaBookChapterItem]) {
+            for item in items {
+                if titles[item.page] == nil, !item.title.isEmpty {
+                    titles[item.page] = item.title
+                }
+                walk(item.children ?? [])
+            }
+        }
+        walk(toc)
+
+        // spine pages with a toc title start a new chapter, untitled pages are
+        // grouped into the preceding one; without a toc, every page is its own chapter
+        var groups: [(start: Int, title: String?)] = []
+        for page in 0..<pages {
+            let title = titles[page]
+            if titles.isEmpty || title != nil || groups.isEmpty {
+                groups.append((page, title))
+            }
+        }
+
+        let noVolume = volume.resolvedNumber < 0 || volume.resolvedNumber >= 100000
+        return groups.enumerated().map { index, group in
+            let end = index + 1 < groups.count ? groups[index + 1].start : pages
+            return .init(
+                key: "\(id)/\(group.start)-\(end)",
+                title: group.title,
+                chapterNumber: Float(index + 1),
+                volumeNumber: noVolume ? nil : volume.resolvedNumber,
+                dateUploaded: createdUtc,
+                url: URL(string: "library/1/series/\(volume.seriesId)/chapter/\(id)", relativeTo: baseUrl),
+                language: language,
+                thumbnail: URL(
+                    string: "api/image/chapter-cover?chapterId=\(id)&apiKey=\(apiKey)",
                     relativeTo: baseUrl
                 )?.absoluteString
             )

--- a/Shared/Sources/Kavita/KavitaModels.swift
+++ b/Shared/Sources/Kavita/KavitaModels.swift
@@ -305,15 +305,16 @@ extension KavitaVolume.Chapter {
     ) -> [AidokuRunner.Chapter] {
         // first toc title per spine page
         var titles: [Int: String] = [:]
-        func walk(_ items: [KavitaBookChapterItem]) {
-            for item in items {
-                if titles[item.page] == nil, !item.title.isEmpty {
-                    titles[item.page] = item.title
-                }
-                walk(item.children ?? [])
+        var items = toc
+        var index = 0
+        while index < items.count {
+            let item = items[index]
+            if titles[item.page] == nil, !item.title.isEmpty {
+                titles[item.page] = item.title
             }
+            items.append(contentsOf: item.children ?? [])
+            index += 1
         }
-        walk(toc)
 
         // spine pages with a toc title start a new chapter, untitled pages are
         // grouped into the preceding one; without a toc, every page is its own chapter

--- a/Shared/Sources/Kavita/KavitaSource.swift
+++ b/Shared/Sources/Kavita/KavitaSource.swift
@@ -190,7 +190,34 @@ actor KavitaSourceRunner: Runner {
                 lastWorkingMirror: &lastWorkingMirrorCopy
             )
             baseUrl = lastWorkingMirrorCopy ?? baseUrl
-            var chapters = volumes.flatMap { $0.intoChapters(baseUrl: baseUrl, apiKey: apiKey) }
+
+            // epub chapters are split into their logical chapters via the book toc
+            var epubTocs: [Int: [KavitaBookChapterItem]] = [:]
+            await withTaskGroup(of: (Int, [KavitaBookChapterItem]?).self) { [helper] taskGroup in
+                for chapter in volumes.flatMap({ $0.chapters }) where chapter.isEpub {
+                    taskGroup.addTask { [lastWorkingMirrorCopy] in
+                        var mirror = lastWorkingMirrorCopy
+                        let toc: [KavitaBookChapterItem]? = try? await helper.request(
+                            path: "api/book/\(chapter.id)/chapters",
+                            lastWorkingMirror: &mirror
+                        )
+                        if toc == nil {
+                            LogManager.logger.error("Kavita: failed to load epub toc for chapter \(chapter.id)")
+                        }
+                        return (chapter.id, toc)
+                    }
+                }
+                for await (id, toc) in taskGroup {
+                    epubTocs[id] = toc
+                }
+            }
+
+            // books read left to right, unlike the rtl manga default
+            if manga.viewer == .unknown && volumes.contains(where: { $0.chapters.contains { $0.isEpub } }) {
+                manga.viewer = .leftToRight
+            }
+
+            var chapters = volumes.flatMap { $0.intoChapters(baseUrl: baseUrl, apiKey: apiKey, epubTocs: epubTocs) }
             chapters.sort { a, b in
                 if a.volumeNumber == b.volumeNumber {
                     if a.chapterNumber == b.chapterNumber {
@@ -213,6 +240,11 @@ actor KavitaSourceRunner: Runner {
     }
 
     func getPageList(manga: AidokuRunner.Manga, chapter: AidokuRunner.Chapter) async throws -> [AidokuRunner.Page] {
+        // epub chapter keys have the format "<kavita chapter id>/<first spine page>-<end spine page>"
+        if chapter.key.contains("/") {
+            return try await getEpubPageList(key: chapter.key)
+        }
+
         var baseUrl = try helper.getConfiguredServer()
         let apiKey = helper.getApiKey()
 
@@ -231,6 +263,42 @@ actor KavitaSourceRunner: Runner {
                 .init(content: .url(url: $0))
             }
         }
+    }
+
+    /// Load the pages of an epub chapter: the chapter's spine pages are
+    /// fetched as html from the book api and converted into a single markdown
+    /// text page for the text reader.
+    private func getEpubPageList(key: String) async throws -> [AidokuRunner.Page] {
+        let parts = key.split(separator: "/")
+        let range = parts.count == 2 ? parts[1].split(separator: "-").compactMap { Int($0) } : []
+        guard let chapterId = parts.first.map(String.init), range.count == 2 else {
+            throw SourceError.message("Invalid epub chapter key")
+        }
+        let baseUrl = try helper.getConfiguredServer()
+
+        var segments: [EpubParser.Segment] = []
+        for page in range[0]..<range[1] {
+            guard let html = try? await helper.requestString(path: "api/book/\(chapterId)/book-page?page=\(page)") else {
+                LogManager.logger.error("Kavita: failed to load epub page \(page) of chapter \(chapterId)")
+                continue
+            }
+            segments += EpubParser.segments(fromHTML: html, basePath: "")
+        }
+        guard !segments.isEmpty else {
+            throw SourceError.message("Failed to load epub chapter")
+        }
+
+        // image urls in the served html already carry the api key
+        return await EpubParser.remotePages(
+            segments: segments,
+            cacheKey: "\(sourceKey)/\(chapterId)",
+            imageURL: { ref in
+                if ref.hasPrefix("//") {
+                    return URL(string: (baseUrl.scheme ?? "https") + ":" + ref)
+                }
+                return URL(string: ref, relativeTo: baseUrl)
+            }
+        )
     }
 
     func getMangaList(listing: AidokuRunner.Listing, page: Int) async throws -> AidokuRunner.MangaPageResult {

--- a/Shared/Sources/Kavita/KavitaSource.swift
+++ b/Shared/Sources/Kavita/KavitaSource.swift
@@ -541,6 +541,12 @@ actor KavitaSourceRunner: Runner {
         return request
     }
 
+    func getBaseUrl() async throws -> URL? {
+        try helper.getConfiguredServer()
+    }
+}
+
+extension KavitaSourceRunner {
     func getSettings() async throws -> [Setting] {
         var settings: [Setting] = [
             .init(
@@ -687,10 +693,6 @@ actor KavitaSourceRunner: Runner {
         }
 
         return settings
-    }
-
-    func getBaseUrl() async throws -> URL? {
-        try helper.getConfiguredServer()
     }
 }
 

--- a/Shared/Sources/Komga/KomgaHelper.swift
+++ b/Shared/Sources/Komga/KomgaHelper.swift
@@ -45,15 +45,17 @@ struct KomgaHelper: Sendable {
         path: String,
         method: HttpMethod = .GET,
         body: KomgaSearchBody? = nil,
+        accept: String = "application/json"
     ) async throws(SourceError) -> T {
         var dummy: URL?
-        return try await request(path: path, method: method, body: body, lastWorkingMirror: &dummy)
+        return try await request(path: path, method: method, body: body, accept: accept, lastWorkingMirror: &dummy)
     }
 
     func request<T: Decodable>(
         path: String,
         method: HttpMethod = .GET,
         body: KomgaSearchBody? = nil,
+        accept: String = "application/json",
         lastWorkingMirror: inout URL?
     ) async throws(SourceError) -> T {
         guard let auth = getAuthorizationHeader() else {
@@ -85,7 +87,7 @@ struct KomgaHelper: Sendable {
             }
             var request = URLRequest(url: url)
             request.setValue(auth, forHTTPHeaderField: "Authorization")
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
+            request.setValue(accept, forHTTPHeaderField: "Accept")
             request.httpMethod = method.stringValue
             if let body {
                 let encoder = JSONEncoder()
@@ -149,6 +151,23 @@ struct KomgaHelper: Sendable {
         }
 
         throw SourceError.networkError
+    }
+
+    // Fetch a raw string response (e.g. epub chapter xhtml).
+    func requestString(path: String) async throws(SourceError) -> String {
+        guard let auth = getAuthorizationHeader() else {
+            throw SourceError.message("NOT_LOGGED_IN")
+        }
+        let url = try getServerUrl(path: path)
+        var request = URLRequest(url: url)
+        request.setValue(auth, forHTTPHeaderField: "Authorization")
+        guard
+            let (data, _) = try? await URLSession.shared.data(for: request),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            throw SourceError.networkError
+        }
+        return string
     }
 }
 

--- a/Shared/Sources/Komga/KomgaHelper.swift
+++ b/Shared/Sources/Komga/KomgaHelper.swift
@@ -58,6 +58,53 @@ struct KomgaHelper: Sendable {
         accept: String = "application/json",
         lastWorkingMirror: inout URL?
     ) async throws(SourceError) -> T {
+        let data = try await requestData(path: path, method: method, body: body, accept: accept, lastWorkingMirror: &lastWorkingMirror)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom({ decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            let formatter = DateFormatter()
+            formatter.timeZone = if #available(iOS 16.0, macOS 13.0, *) {
+                .gmt
+            } else {
+                .init(secondsFromGMT: 0)
+            }
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+            var date = formatter.date(from: string)
+            if date == nil {
+                formatter.dateFormat = "yyyy-MM-dd"
+                date = formatter.date(from: string)
+            }
+            return date ?? .distantPast
+        })
+        if let result = try? decoder.decode(T.self, from: data) {
+            return result
+        } else if let error = try? decoder.decode(KomgaError.self, from: data) {
+            throw SourceError.message(error.error)
+        } else {
+            throw SourceError.message("UNKNOWN_ERROR")
+        }
+    }
+
+    // Fetch a raw string response (e.g. epub chapter xhtml).
+    func requestString(path: String) async throws(SourceError) -> String {
+        var dummy: URL?
+        let data = try await requestData(path: path, accept: nil, lastWorkingMirror: &dummy)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw SourceError.message("UNKNOWN_ERROR")
+        }
+        return string
+    }
+
+    // Fetch raw response data, handling mirrors.
+    func requestData(
+        path: String,
+        method: HttpMethod = .GET,
+        body: KomgaSearchBody? = nil,
+        accept: String? = "application/json",
+        lastWorkingMirror: inout URL?
+    ) async throws(SourceError) -> Data {
         guard let auth = getAuthorizationHeader() else {
             throw SourceError.message("NOT_LOGGED_IN")
         }
@@ -81,13 +128,15 @@ struct KomgaHelper: Sendable {
             URLSession.shared
         }
 
-        func doRequest(baseUrl: URL) async throws(SourceError) -> T {
+        func doRequest(baseUrl: URL) async throws(SourceError) -> Data {
             guard let url = URL(string: path, relativeTo: baseUrl) else {
                 throw SourceError.message("INVALID_SERVER_URL")
             }
             var request = URLRequest(url: url)
             request.setValue(auth, forHTTPHeaderField: "Authorization")
-            request.setValue(accept, forHTTPHeaderField: "Accept")
+            if let accept {
+                request.setValue(accept, forHTTPHeaderField: "Accept")
+            }
             request.httpMethod = method.stringValue
             if let body {
                 let encoder = JSONEncoder()
@@ -105,32 +154,7 @@ struct KomgaHelper: Sendable {
             guard let data = result?.0 else {
                 throw SourceError.networkError
             }
-
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .custom({ decoder in
-                let container = try decoder.singleValueContainer()
-                let string = try container.decode(String.self)
-                let formatter = DateFormatter()
-                formatter.timeZone = if #available(iOS 16.0, macOS 13.0, *) {
-                    .gmt
-                } else {
-                    .init(secondsFromGMT: 0)
-                }
-                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-                var date = formatter.date(from: string)
-                if date == nil {
-                    formatter.dateFormat = "yyyy-MM-dd"
-                    date = formatter.date(from: string)
-                }
-                return date ?? .distantPast
-            })
-            if let result = try? decoder.decode(T.self, from: data) as T? {
-                return result
-            } else if let error = try? decoder.decode(KomgaError.self, from: data) {
-                throw SourceError.message(error.error)
-            } else {
-                throw SourceError.message("UNKNOWN_ERROR")
-            }
+            return data
         }
 
         for (idx, baseUrl) in allBaseUrls.enumerated() {
@@ -151,23 +175,6 @@ struct KomgaHelper: Sendable {
         }
 
         throw SourceError.networkError
-    }
-
-    // Fetch a raw string response (e.g. epub chapter xhtml).
-    func requestString(path: String) async throws(SourceError) -> String {
-        guard let auth = getAuthorizationHeader() else {
-            throw SourceError.message("NOT_LOGGED_IN")
-        }
-        let url = try getServerUrl(path: path)
-        var request = URLRequest(url: url)
-        request.setValue(auth, forHTTPHeaderField: "Authorization")
-        guard
-            let (data, _) = try? await URLSession.shared.data(for: request),
-            let string = String(data: data, encoding: .utf8)
-        else {
-            throw SourceError.networkError
-        }
-        return string
     }
 }
 

--- a/Shared/Sources/Komga/KomgaModels.swift
+++ b/Shared/Sources/Komga/KomgaModels.swift
@@ -272,6 +272,81 @@ extension KomgaBook {
     }
 }
 
+// MARK: Epub Manifest
+
+/// Subset of the Readium WebPub manifest served at `api/v1/books/{id}/manifest`,
+/// used to split epub books into chapters without downloading the file.
+struct KomgaWebPubManifest: Codable, Sendable {
+    struct Link: Codable, Sendable {
+        let href: String
+    }
+
+    struct TocEntry: Codable, Sendable {
+        let title: String?
+        let href: String?
+        let children: [TocEntry]?
+    }
+
+    let readingOrder: [Link]
+    let toc: [TocEntry]?
+}
+
+extension KomgaWebPubManifest {
+    /// The archive-relative path of a resource href, e.g.
+    /// "https://server/api/v1/books/{id}/resource/OEBPS/ch1.xhtml#frag" -> "OEBPS/ch1.xhtml"
+    static func resourcePath(of href: String) -> String {
+        var path = href
+        if let range = path.range(of: "/resource/") {
+            path = String(path[range.upperBound...])
+        }
+        if let hash = path.firstIndex(of: "#") {
+            path = String(path[..<hash])
+        }
+        return path.removingPercentEncoding ?? path
+    }
+
+    /// The spine grouped into logical chapters by TOC titles, like local epubs.
+    func chapters() -> [EpubParser.Chapter] {
+        var titles: [String: String] = [:]
+        func walk(_ entries: [TocEntry]) {
+            for entry in entries {
+                if let href = entry.href, let title = entry.title, !title.isEmpty {
+                    let path = Self.resourcePath(of: href)
+                    if titles[path] == nil {
+                        titles[path] = title
+                    }
+                }
+                walk(entry.children ?? [])
+            }
+        }
+        walk(toc ?? [])
+
+        return EpubParser.groupSpine(
+            hrefs: readingOrder.map { Self.resourcePath(of: $0.href) },
+            titles: titles
+        )
+    }
+}
+
+extension KomgaBook {
+    /// Chapters for an epub book, one per logical epub chapter.
+    /// The chapter key has the format "<book id>/<primary content file path>".
+    func intoEpubChapters(manifest: KomgaWebPubManifest, baseUrl: URL) -> [AidokuRunner.Chapter] {
+        manifest.chapters().enumerated().map { index, chapter in
+            .init(
+                key: "\(id)/\(chapter.href)",
+                title: chapter.title,
+                chapterNumber: Float(index + 1),
+                volumeNumber: metadata.numberSort,
+                dateUploaded: metadata.releaseDate ?? metadata.created,
+                url: URL(string: "book/\(id)", relativeTo: baseUrl),
+                language: "en",
+                thumbnail: URL(string: "api/v1/books/\(id)/thumbnail", relativeTo: baseUrl)?.absoluteString,
+            )
+        }
+    }
+}
+
 // MARK: Series
 
 struct KomgaSeries: Codable, Sendable {

--- a/Shared/Sources/Komga/KomgaModels.swift
+++ b/Shared/Sources/Komga/KomgaModels.swift
@@ -308,18 +308,19 @@ extension KomgaWebPubManifest {
     /// The spine grouped into logical chapters by TOC titles, like local epubs.
     func chapters() -> [EpubParser.Chapter] {
         var titles: [String: String] = [:]
-        func walk(_ entries: [TocEntry]) {
-            for entry in entries {
-                if let href = entry.href, let title = entry.title, !title.isEmpty {
-                    let path = Self.resourcePath(of: href)
-                    if titles[path] == nil {
-                        titles[path] = title
-                    }
+        var entries = toc ?? []
+        var index = 0
+        while index < entries.count {
+            let entry = entries[index]
+            if let href = entry.href, let title = entry.title, !title.isEmpty {
+                let path = Self.resourcePath(of: href)
+                if titles[path] == nil {
+                    titles[path] = title
                 }
-                walk(entry.children ?? [])
             }
+            entries.append(contentsOf: entry.children ?? [])
+            index += 1
         }
-        walk(toc ?? [])
 
         return EpubParser.groupSpine(
             hrefs: readingOrder.map { Self.resourcePath(of: $0.href) },

--- a/Shared/Sources/Komga/KomgaSource.swift
+++ b/Shared/Sources/Komga/KomgaSource.swift
@@ -179,20 +179,60 @@ actor KomgaSourceRunner: Runner {
                 lastWorkingMirror: &lastWorkingMirrorCopy
             )
 
-            manga.chapters = chapters.content
-                .filter { $0.media.mediaProfile != "EPUB" || $0.media.epubDivinaCompatible } // can't read epubs (yet?)
-                .map {
-                    $0.intoChapter(
-                        baseUrl: lastWorkingMirrorCopy ?? baseUrl,
-                        useChapters: UserDefaults.standard.bool(forKey: "\(sourceKey).useChapters")
-                    )
+            let chapterBaseUrl = lastWorkingMirrorCopy ?? baseUrl
+            let useChapters = UserDefaults.standard.bool(forKey: "\(sourceKey).useChapters")
+
+            var chapterGroups: [[AidokuRunner.Chapter]] = chapters.content.map {
+                [$0.intoChapter(baseUrl: chapterBaseUrl, useChapters: useChapters)]
+            }
+
+            // epub books are split into their logical chapters via the webpub manifest
+            await withTaskGroup(of: (Int, [AidokuRunner.Chapter]).self) { [helper] taskGroup in
+                for (index, book) in chapters.content.enumerated()
+                where book.media.mediaProfile == "EPUB" && !book.media.epubDivinaCompatible {
+                    taskGroup.addTask { [lastWorkingMirrorCopy] in
+                        var mirror = lastWorkingMirrorCopy
+                        let manifest: KomgaWebPubManifest? = try? await helper.request(
+                            path: "api/v1/books/\(book.id)/manifest",
+                            accept: "application/webpub+json",
+                            lastWorkingMirror: &mirror
+                        )
+                        guard let manifest else {
+                            LogManager.logger.error("Komga: failed to load epub manifest for book \(book.id)")
+                            return (index, [])
+                        }
+                        // newest first, matching the descending book order
+                        return (index, Array(book.intoEpubChapters(manifest: manifest, baseUrl: chapterBaseUrl).reversed()))
+                    }
                 }
+                for await (index, epubChapters) in taskGroup {
+                    chapterGroups[index] = epubChapters
+                }
+            }
+
+            manga.chapters = chapterGroups.flatMap { $0 }
+
+            // books read left to right, unlike the rtl manga default; only
+            // applied when the server doesn't specify a reading direction
+            let hasEpubBooks = chapters.content.contains {
+                $0.media.mediaProfile == "EPUB" && !$0.media.epubDivinaCompatible
+            }
+            if hasEpubBooks && manga.viewer == .unknown {
+                manga.viewer = .leftToRight
+            }
         }
 
         return manga
     }
 
     func getPageList(manga: AidokuRunner.Manga, chapter: AidokuRunner.Chapter) async throws -> [AidokuRunner.Page] {
+        // epub chapter keys have the format "<book id>/<content file path>"
+        if let separator = chapter.key.firstIndex(of: "/") {
+            let bookId = String(chapter.key[..<separator])
+            let href = String(chapter.key[chapter.key.index(after: separator)...])
+            return try await getEpubPageList(bookId: bookId, href: href)
+        }
+
         var lastWorkingMirrorCopy = lastWorkingMirror
         defer {
             lastWorkingMirror = lastWorkingMirrorCopy
@@ -220,6 +260,54 @@ actor KomgaSourceRunner: Runner {
                 .init(content: .url(url: $0))
             }
         }
+    }
+
+    /// Load the pages of an epub chapter: the chapter's xhtml files are
+    /// fetched from the book resource endpoint and converted into a single
+    /// markdown text page for the text reader.
+    private func getEpubPageList(bookId: String, href: String) async throws -> [AidokuRunner.Page] {
+        let baseUrl = try helper.getConfiguredServer()
+        let manifest: KomgaWebPubManifest = try await helper.request(
+            path: "api/v1/books/\(bookId)/manifest",
+            accept: "application/webpub+json"
+        )
+        // grouped continuation files for this chapter
+        let hrefs = manifest.chapters().first { $0.href == href }?.hrefs ?? [href]
+
+        var segments: [EpubParser.Segment] = []
+        for href in hrefs {
+            let escaped = href.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? href
+            guard let html = try? await helper.requestString(path: "api/v1/books/\(bookId)/resource/\(escaped)") else {
+                LogManager.logger.error("Komga: failed to load epub chapter file \(href) of book \(bookId)")
+                continue
+            }
+            segments += EpubParser.segments(fromHTML: html, basePath: EpubParser.directory(of: href))
+        }
+        guard !segments.isEmpty else {
+            throw SourceError.message("Failed to load epub chapter")
+        }
+
+        let auth = helper.getAuthorizationHeader()
+        return await EpubParser.remotePages(
+            segments: segments,
+            cacheKey: "\(sourceKey)/\(bookId)",
+            imageURL: { ref in
+                if ref.hasPrefix("http://") || ref.hasPrefix("https://") {
+                    return URL(string: ref)
+                }
+                if ref.hasPrefix("//") {
+                    return URL(string: (baseUrl.scheme ?? "https") + ":" + ref)
+                }
+                let escaped = ref.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ref
+                return URL(string: "api/v1/books/\(bookId)/resource/\(escaped)", relativeTo: baseUrl)
+            },
+            authorize: { request in
+                // only send credentials to the configured server
+                if let auth, request.url?.host == baseUrl.host {
+                    request.setValue(auth, forHTTPHeaderField: "Authorization")
+                }
+            }
+        )
     }
 
     func getMangaList(listing: AidokuRunner.Listing, page: Int) async throws -> AidokuRunner.MangaPageResult {

--- a/Shared/Sources/Komga/KomgaSource.swift
+++ b/Shared/Sources/Komga/KomgaSource.swift
@@ -518,6 +518,12 @@ actor KomgaSourceRunner: Runner {
         return request
     }
 
+    func getBaseUrl() async throws -> URL? {
+        try helper.getConfiguredServer()
+    }
+}
+
+extension KomgaSourceRunner {
     func getSettings() async throws -> [Setting] {
         var settings: [Setting] = [
             .init(
@@ -610,10 +616,6 @@ actor KomgaSourceRunner: Runner {
             )
         ])
         return settings
-    }
-
-    func getBaseUrl() async throws -> URL? {
-        try helper.getConfiguredServer()
     }
 
     func handleBasicLogin(key _: String, username email: String, password: String) async throws -> Bool {

--- a/Shared/Sources/Local/EpubParser.swift
+++ b/Shared/Sources/Local/EpubParser.swift
@@ -11,6 +11,7 @@
 //  packages (e.g. <opf:item>, <odc:rootfile>) parse the same as unprefixed ones.
 //
 
+import AidokuRunner
 import Foundation
 import SwiftSoup
 import ZIPFoundation
@@ -170,6 +171,34 @@ enum EpubParser {
         )
     }
 
+    /// Group spine files into logical chapters using TOC titles: files with a
+    /// TOC entry start a new chapter, files without one (illustrations, chapter
+    /// continuations) are grouped into the preceding chapter. Without any
+    /// titles, every file is its own chapter.
+    static func groupSpine(hrefs: [String], titles: [String: String]) -> [Chapter] {
+        var chapters: [Chapter] = []
+        var currentHrefs: [String] = []
+        var currentTitle: String?
+        func flushChapter() {
+            if !currentHrefs.isEmpty {
+                chapters.append(Chapter(hrefs: currentHrefs, title: currentTitle))
+            }
+            currentHrefs = []
+            currentTitle = nil
+        }
+        let hasTitles = !titles.isEmpty
+        for href in hrefs {
+            let title = titles[href]
+            if !hasTitles || title != nil {
+                flushChapter()
+                currentTitle = title
+            }
+            currentHrefs.append(href)
+        }
+        flushChapter()
+        return chapters
+    }
+
     // MARK: - Chapter Content
 
     /// Extract a chapter's XHTML from the archive and convert it into
@@ -303,16 +332,17 @@ enum EpubParser {
 
     private static let blockTags: Set<String> = ["h1", "h2", "h3", "h4", "h5", "h6", "p", "blockquote", "li"]
 
-    /// Resolve an image element's source to an archive path, ignoring external and data urls.
+    /// Resolve an image element's source to an archive path, ignoring data urls.
+    /// Remote urls are passed through unresolved; local archives drop them
+    /// during entry lookup, while server sources fetch them directly.
     private static func imagePath(of element: Element, basePath: String) -> String? {
         let src = [attr(element, "src"), attr(element, "xlink:href"), attr(element, "href")]
             .compactMap { $0 }
             .first
-        guard
-            let src,
-            !src.hasPrefix("data:"),
-            !src.hasPrefix("http://"), !src.hasPrefix("https://")
-        else { return nil }
+        guard let src, !src.hasPrefix("data:") else { return nil }
+        if src.hasPrefix("http://") || src.hasPrefix("https://") || src.hasPrefix("//") {
+            return src
+        }
         return resolve(href: stripFragment(src), relativeTo: basePath)
     }
 
@@ -454,7 +484,7 @@ enum EpubParser {
 
     // MARK: - Path Helpers
 
-    private static func directory(of path: String) -> String {
+    static func directory(of path: String) -> String {
         path.split(separator: "/").dropLast().joined(separator: "/")
     }
 
@@ -477,5 +507,100 @@ enum EpubParser {
             }
         }
         return components.joined(separator: "/")
+    }
+}
+
+// MARK: - Reader Pages
+
+extension EpubParser {
+    /// Build reader pages from chapter segments: text chapters become a
+    /// single markdown page with inline image references, image-only chapters
+    /// (cover, illustration galleries) become one page per image for the
+    /// image reader. The data source only supplies the two image lookups:
+    /// `inlineImageURL` resolves an image ref to a local file url for
+    /// markdown, `imagePage` builds the page content for image-only chapters.
+    static func pages(
+        segments: [Segment],
+        inlineImageURL: (String) async -> URL?,
+        imagePage: (String) -> AidokuRunner.PageContent?
+    ) async -> [AidokuRunner.Page] {
+        let hasText = segments.contains {
+            if case .text = $0 { return true }
+            return false
+        }
+
+        if hasText {
+            var parts: [String] = []
+            for segment in segments {
+                switch segment {
+                    case .text(let text):
+                        parts.append(text)
+                    case .image(let ref):
+                        guard let fileURL = await inlineImageURL(ref) else { continue }
+                        parts.append("![image](\(fileURL.absoluteString))")
+                }
+            }
+            guard !parts.isEmpty else { return [] }
+            return [AidokuRunner.Page(content: .text(parts.joined(separator: "\n\n")))]
+        }
+
+        return segments.compactMap { segment in
+            guard case let .image(ref) = segment, let content = imagePage(ref) else { return nil }
+            return AidokuRunner.Page(content: content)
+        }
+    }
+
+    /// `pages(segments:...)` for a chapter fetched from a media server
+    /// (Komga/Kavita): inline images are downloaded to the local cache,
+    /// image-only chapters become url pages loaded through the source's
+    /// image requests.
+    static func remotePages(
+        segments: [Segment],
+        cacheKey: String,
+        imageURL: (String) -> URL?,
+        authorize: (inout URLRequest) -> Void = { _ in }
+    ) async -> [AidokuRunner.Page] {
+        await pages(
+            segments: segments,
+            inlineImageURL: { ref in
+                guard let url = imageURL(ref) else { return nil }
+                return await cacheRemoteImage(url: url, cacheKey: cacheKey, authorize: authorize)
+            },
+            imagePage: { ref in
+                imageURL(ref).map { .url(url: $0) }
+            }
+        )
+    }
+
+    /// Download an inline image into the epub image cache so it can be
+    /// referenced with a file url from markdown text. Small decorative images
+    /// are dropped, matching the local <100 KB heuristic in `chapterSegments`.
+    private static func cacheRemoteImage(
+        url: URL,
+        cacheKey: String,
+        authorize: (inout URLRequest) -> Void
+    ) async -> URL? {
+        guard let bookDir = LocalFileManager.epubImageCacheDirectory(forKey: cacheKey) else { return nil }
+        let fileURL = bookDir.appendingPathComponent(LocalFileManager.fnvHash(url.absoluteString))
+
+        if !fileURL.exists {
+            var request = URLRequest(url: url)
+            authorize(&request)
+            guard
+                let (data, _) = try? await URLSession.shared.data(for: request),
+                !data.isEmpty
+            else { return nil }
+            bookDir.createDirectory()
+            do {
+                try data.write(to: fileURL)
+            } catch {
+                LogManager.logger.error("EpubParser: failed to cache remote image \(url): \(error)")
+                return nil
+            }
+        }
+
+        let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard size >= 100_000 else { return nil }
+        return fileURL
     }
 }

--- a/Shared/Sources/Local/LocalFileManager.swift
+++ b/Shared/Sources/Local/LocalFileManager.swift
@@ -151,14 +151,14 @@ extension LocalFileManager {
         let documentsDir = FileManager.default.documentDirectory
         let archiveURL = documentsDir.appendingPathComponent(cbzPath)
         if archiveURL.pathExtension.lowercased() == "epub" {
-            return readEpubPages(from: archiveURL, chapterId: chapterId)
+            return await readEpubPages(from: archiveURL, chapterId: chapterId)
         }
         return readPages(from: archiveURL)
     }
 
     // read the pages for an epub chapter
     // the chapter id has the format "<epub file name>/<content file path>"
-    nonisolated func readEpubPages(from archiveURL: URL, chapterId: String) -> [AidokuRunner.Page] {
+    nonisolated func readEpubPages(from archiveURL: URL, chapterId: String) async -> [AidokuRunner.Page] {
         let prefix = archiveURL.lastPathComponent + "/"
         let href = chapterId.hasPrefix(prefix) ? String(chapterId.dropFirst(prefix.count)) : chapterId
         let segments = EpubParser.chapterSegments(url: archiveURL, href: href)
@@ -167,52 +167,36 @@ extension LocalFileManager {
             return []
         }
 
-        let hasText = segments.contains {
-            if case .text = $0 { return true }
-            return false
-        }
-
-        if hasText {
-            // build a single markdown page with inline image references so the
-            // whole chapter stays in the text reader
-            let parts: [String] = segments.compactMap { segment in
-                switch segment {
-                    case .text(let text):
-                        return text
-                    case .image(let path):
-                        guard let cachedURL = Self.cacheEpubImage(archiveURL: archiveURL, path: path) else {
-                            return nil
-                        }
-                        return "![image](\(cachedURL.absoluteString))"
-                }
-            }
-            return [AidokuRunner.Page(content: .text(parts.joined(separator: "\n\n")))]
-        }
-
-        // image-only chapter (cover, illustration pages)
-        return segments.compactMap { segment in
-            guard case let .image(path) = segment else { return nil }
-            return AidokuRunner.Page(content: .zipFile(url: archiveURL, filePath: path))
-        }
+        return await EpubParser.pages(
+            segments: segments,
+            inlineImageURL: { Self.cacheEpubImage(archiveURL: archiveURL, path: $0) },
+            imagePage: { .zipFile(url: archiveURL, filePath: $0) }
+        )
     }
 
     // cache directory for extracted images of a given epub archive
     nonisolated static func epubImageCacheDirectory(for archiveURL: URL) -> URL? {
+        epubImageCacheDirectory(forKey: archiveURL.path)
+    }
+
+    // cache directory for the inline images of an epub book, identified by a
+    // stable key (local archive path or server source book id)
+    nonisolated static func epubImageCacheDirectory(forKey key: String) -> URL? {
         guard let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
         else { return nil }
 
-        // stable per-book folder name (fnv-1a hash)
-        func hash(_ string: String) -> String {
-            var hash: UInt64 = 0xcbf29ce484222325
-            for byte in string.utf8 {
-                hash = (hash ^ UInt64(byte)) &* 0x100000001b3
-            }
-            return String(hash, radix: 16)
-        }
-
         return cachesDir
             .appendingPathComponent("EpubImages", isDirectory: true)
-            .appendingPathComponent(hash(archiveURL.path), isDirectory: true)
+            .appendingPathComponent(fnvHash(key), isDirectory: true)
+    }
+
+    // stable file/folder name for a string (fnv-1a hash)
+    nonisolated static func fnvHash(_ string: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in string.utf8 {
+            hash = (hash ^ UInt64(byte)) &* 0x100000001b3
+        }
+        return String(hash, radix: 16)
     }
 
     // extract an image from an epub archive into the cache directory so it can


### PR DESCRIPTION
Closes #1022

## Summary

Adds EPUB reading support to the Komga and Kavita sources. Previously, EPUB books were filtered out of Komga chapter lists (unless Divina-compatible) and skipped entirely for Kavita. They now show up as regular chapters and open in the text reader, matching the experience of the local files source.

## How it works

EPUBs are not downloaded. Instead, both servers' book APIs are used to split each book into its logical chapters and fetch content on demand:

- **Komga**: The WebPub manifest (`api/v1/books/{id}/manifest`) provides the spine and TOC, which are grouped into chapters the same way the local `EpubParser` does (spine files with a TOC title start a new chapter). Chapter content is fetched from the `resource/` endpoint as XHTML and converted to markdown. Chapter keys use the format `<bookId>/<content file path>`.
- **Kavita**: The book TOC (`api/book/{id}/chapters`) maps spine page indices to titles; content comes from `book-page?page=N`. Chapter keys use the format `<chapterId>/<startPage>-<endPage>`.

Rendering reuses the existing local EPUB pipeline: `EpubParser.segments(fromHTML:)` converts XHTML to text/image segments, and a new shared `EpubParser.pages(...)` builds the reader pages for both local and server sources (the data source only supplies image lookup closures). Text chapters become a single markdown text page with inline images (downloaded to the existing `EpubImages` cache, since the text readers only render local file URLs); image-only chapters (covers, illustration galleries) become regular image pages served through the source's authenticated image requests.

Since books read left-to-right, series containing EPUBs default to LTR — for Komga only when the server doesn't specify a reading direction.

## Also fixed

- `KomgaHelper` now supports custom `Accept` headers; the manifest endpoint returns `application/webpub+json` and responds with 406 to `application/json`.
- Kavita volumes with fractional numbers (e.g. 9.5) were displayed truncated (9), because only the legacy integer `number` field was decoded. The model now prefers `minNumber`. This affected all Kavita series, not just EPUBs.

## Notes

- No project file changes; all code lives in existing files.
- Existing chapter keys are unaffected: non-EPUB books and Divina-compatible EPUBs keep their current keys and behavior.
- Tested against real Komga and Kavita servers as well as the public demo servers (demo.komga.org, demo.kavitareader.com), including text chapters with inline illustrations, image-only cover chapters, EPUB 2/3 TOC variants, and books without a TOC.
- The second part of #1022 (external sources providing direct EPUB links) is not included — that needs an AidokuRunner API change and would make sense as a follow-up.
