### PR TITLE
fix: text reader crash fixes and tolerant epub archive lookup

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -599,7 +599,9 @@
 		FBF9DC0628205FCE0056FA9A /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF9DC0428205FCE0056FA9A /* DownloadManager.swift */; };
 		FBFA43AD2799DD110065A445 /* ReaderSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA43AC2799DD110065A445 /* ReaderSliderView.swift */; };
 		FBFDD40327838AB90055ED9F /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFDD40227838AB90055ED9F /* Sequence.swift */; };
+		00A1B2C42EA7F1000012AB01 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A1B2C32EA7F1000012AB01 /* Archive.swift */; };
 		FBFDD40427838AB90055ED9F /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFDD40227838AB90055ED9F /* Sequence.swift */; };
+		00A1B2C52EA7F1000012AB01 /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A1B2C32EA7F1000012AB01 /* Archive.swift */; };
 		FBFDF5F82DF799180064F603 /* AidokuRunner in Frameworks */ = {isa = PBXBuildFile; productRef = FBFDF5F72DF799180064F603 /* AidokuRunner */; };
 		FBFDF5FA2DF799340064F603 /* AidokuRunner in Frameworks */ = {isa = PBXBuildFile; productRef = FBFDF5F92DF799340064F603 /* AidokuRunner */; };
 		FBFF58912E7F2642009367B7 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFF58902E7F2641009367B7 /* Settings.swift */; };
@@ -1095,6 +1097,7 @@
 		FBFAC3BB2996B292004D8489 /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FBFAC3BC2996B2CB004D8489 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FBFDD40227838AB90055ED9F /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
+		00A1B2C32EA7F1000012AB01 /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
 		FBFF58902E7F2641009367B7 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		FBFF58922E7F2BEF009367B7 /* SettingView+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingView+Environment.swift"; sourceTree = "<group>"; };
 		FBFF58942E807280009367B7 /* DoneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneButton.swift; sourceTree = "<group>"; };
@@ -1537,6 +1540,7 @@
 				FB4B0AE2285CCC8E0066A13B /* URL.swift */,
 				FB4B0AE7285D0A0E0066A13B /* Dictionary.swift */,
 				FBFDD40227838AB90055ED9F /* Sequence.swift */,
+				00A1B2C32EA7F1000012AB01 /* Archive.swift */,
 				FB4B0AF0285D46BF0066A13B /* Date.swift */,
 				FB7B7EDC278CEAA2001E6EAF /* URLSession.swift */,
 				FB7B7ED9278CEA6A001E6EAF /* FileManager.swift */,
@@ -2699,6 +2703,7 @@
 				FB1B4868277CE76B0056D02C /* MangaModels.swift in Sources */,
 				4824125A2B771E060096788C /* MangaUpdateItemView.swift in Sources */,
 				FBFDD40327838AB90055ED9F /* Sequence.swift in Sources */,
+				00A1B2C42EA7F1000012AB01 /* Archive.swift in Sources */,
 				FB7F05F42DDCCF4A0036B116 /* ReaderPageDescriptionButtonView.swift in Sources */,
 				FB6340CE27947BCA0072A2A2 /* ExternalSourceInfo.swift in Sources */,
 				FB3F49EB2B7C6B7700D3CC75 /* ChapterFlagMask.swift in Sources */,
@@ -3165,6 +3170,7 @@
 				FB67EE6127F3708500C468EA /* WasmImports.swift in Sources */,
 				FBED233527C095FC0095D0C0 /* SourceObject.swift in Sources */,
 				FBFDD40427838AB90055ED9F /* Sequence.swift in Sources */,
+				00A1B2C52EA7F1000012AB01 /* Archive.swift in Sources */,
 				FB716E00283DA2D900F1BB5D /* LogStore.swift in Sources */,
 				FBF9259B2F4DFB7A0049CB43 /* MangaBakaApi.swift in Sources */,
 				56815D992FBC7078001486C8 /* NotificationManager.swift in Sources */,

--- a/AidokuTests/ArchiveTests.swift
+++ b/AidokuTests/ArchiveTests.swift
@@ -1,0 +1,84 @@
+//
+//  ArchiveTests.swift
+//  Aidoku
+//
+
+import Foundation
+import Testing
+import ZIPFoundation
+@testable import Aidoku
+
+@Suite struct ArchiveTests {
+    /// Builds an archive on disk containing one entry per given path.
+    private func makeArchive(paths: [String]) throws -> (Archive, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("zip")
+        let archive = try Archive(url: url, accessMode: .create)
+        let data = Data("contents".utf8)
+        for path in paths {
+            try archive.addEntry(
+                with: path,
+                type: .file,
+                uncompressedSize: Int64(data.count),
+                provider: { position, size in
+                    data.subdata(in: Int(position)..<Int(position) + size)
+                }
+            )
+        }
+        return (archive, url)
+    }
+
+    @Test("Entries written with a ./ prefix resolve")
+    func resolvesDotSlashPrefix() throws {
+        let (archive, url) = try makeArchive(paths: ["./OEBPS/ch1.xhtml"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(archive["OEBPS/ch1.xhtml"] == nil)
+        #expect(archive.entry(at: "OEBPS/ch1.xhtml") != nil)
+    }
+
+    @Test("Percent-encoded entries resolve from a decoded path")
+    func resolvesPercentEncodedEntry() throws {
+        let (archive, url) = try makeArchive(paths: ["OEBPS/images/plate%20one.png"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // EpubParser.resolve(href:relativeTo:) decodes every href, so lookups
+        // arrive decoded even when the archive stored the entry encoded
+        #expect(archive["OEBPS/images/plate one.png"] == nil)
+        #expect(archive.entry(at: "OEBPS/images/plate one.png") != nil)
+    }
+
+    @Test("A ./ prefixed entry resolves from a decoded path")
+    func resolvesDotSlashPrefixWithSpace() throws {
+        let (archive, url) = try makeArchive(paths: ["./OEBPS/images/plate one.png"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(archive["OEBPS/images/plate one.png"] == nil)
+        #expect(archive.entry(at: "OEBPS/images/plate one.png") != nil)
+    }
+
+    @Test("Lookup is case insensitive")
+    func resolvesDifferingCase() throws {
+        let (archive, url) = try makeArchive(paths: ["OEBPS/Cover.PNG"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(archive.entry(at: "OEBPS/cover.png") != nil)
+    }
+
+    @Test("An exact match is returned unchanged")
+    func prefersExactMatch() throws {
+        let (archive, url) = try makeArchive(paths: ["OEBPS/ch1.xhtml"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(archive.entry(at: "OEBPS/ch1.xhtml")?.path == "OEBPS/ch1.xhtml")
+    }
+
+    @Test("A genuinely absent path returns nil")
+    func returnsNilWhenAbsent() throws {
+        let (archive, url) = try makeArchive(paths: ["OEBPS/ch1.xhtml"])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(archive.entry(at: "OEBPS/missing.xhtml") == nil)
+    }
+}

--- a/AidokuTests/TextPaginatorTests.swift
+++ b/AidokuTests/TextPaginatorTests.swift
@@ -1,0 +1,53 @@
+//
+//  TextPaginatorTests.swift
+//  Aidoku
+//
+
+import Testing
+import UIKit
+@testable import Aidoku
+
+@Suite struct TextPaginatorTests {
+    private let pageSize = CGSize(width: 320, height: 480)
+
+    @Test("Text with emoji after sentence breaks paginates without crashing")
+    func paginateEmojiAfterSentenceBreak() {
+        // Regression test: the sentence-break search reads the UTF-16 code unit
+        // following a sentence ender; when that character is an emoji (surrogate
+        // pair), UnicodeScalar(UInt16) is nil and was previously force-unwrapped.
+        // A single paragraph (no newlines) forces the sentence-break path.
+        let sentence = "Some words that fill space before the period.\u{1F600} And then more words follow here. "
+        let markdown = String(repeating: sentence, count: 200)
+            .replacingOccurrences(of: "\n", with: " ")
+
+        let paginator = TextPaginator()
+        let pages = paginator.paginate(markdown: markdown, pageSize: pageSize)
+
+        #expect(!pages.isEmpty)
+        #expect(pages.count > 1)
+    }
+
+    @Test("Page ranges are contiguous and cover the whole text")
+    func pageRangesAreContiguous() {
+        let markdown = String(repeating: "A reasonably long paragraph of plain text to fill several pages.\n\n", count: 100)
+
+        let paginator = TextPaginator()
+        let pages = paginator.paginate(markdown: markdown, pageSize: pageSize)
+
+        #expect(pages.count > 1)
+        for (index, page) in pages.enumerated() {
+            #expect(page.id == index)
+            #expect(page.range.length > 0)
+            if index > 0 {
+                let previous = pages[index - 1]
+                #expect(page.range.location == previous.range.location + previous.range.length)
+            }
+        }
+    }
+
+    @Test("Empty markdown does not crash")
+    func paginateEmptyMarkdown() {
+        let paginator = TextPaginator()
+        _ = paginator.paginate(markdown: "", pageSize: pageSize)
+    }
+}

--- a/Shared/Extensions/Archive.swift
+++ b/Shared/Extensions/Archive.swift
@@ -1,0 +1,29 @@
+//
+//  Archive.swift
+//  Aidoku
+//
+//  Created by Pietro Baiguini on 8/9/26.
+//
+
+import ZIPFoundation
+
+extension Archive {
+    /// Looks up an entry by path, tolerating the variations archives use for the same file.
+    ///
+    /// The subscript requires an exact match, so entries written with a `./` prefix or with
+    /// percent-encoded characters (common when file names contain spaces or non-ASCII
+    /// characters) fail to resolve. This falls back to a case-insensitive comparison against
+    /// both the normalised and the percent-decoded path.
+    func entry(at path: String) -> Entry? {
+        if let entry = self[path] { return entry }
+        let target = path.lowercased()
+        return first { entry in
+            var entryPath = entry.path
+            if entryPath.hasPrefix("./") {
+                entryPath = String(entryPath.dropFirst(2))
+            }
+            return entryPath.lowercased() == target
+                || (entryPath.removingPercentEncoding ?? entryPath).lowercased() == target
+        }
+    }
+}

--- a/Shared/Sources/Local/EpubParser.swift
+++ b/Shared/Sources/Local/EpubParser.swift
@@ -212,7 +212,7 @@ enum EpubParser {
         // chapters are practically always larger
         let filtered: [Segment] = segments.compactMap { segment in
             guard case let .image(path) = segment else { return segment }
-            guard let entry = entry(in: archive, path: path) else { return nil }
+            guard let entry = archive.entry(at: path) else { return nil }
             if hasText && entry.uncompressedSize < 100_000 { return nil }
             return segment
         }
@@ -421,21 +421,8 @@ enum EpubParser {
     // MARK: - Archive Helpers
 
     /// Look up an archive entry, tolerating "./" prefixes, percent-encoding, and case differences.
-    static func entry(in archive: Archive, path: String) -> Entry? {
-        if let entry = archive[path] { return entry }
-        let target = path.lowercased()
-        return archive.first { entry in
-            var entryPath = entry.path
-            if entryPath.hasPrefix("./") {
-                entryPath = String(entryPath.dropFirst(2))
-            }
-            return entryPath.lowercased() == target
-                || (entryPath.removingPercentEncoding ?? entryPath).lowercased() == target
-        }
-    }
-
     private static func extractData(from archive: Archive, path: String) -> Data? {
-        guard let entry = entry(in: archive, path: path) else { return nil }
+        guard let entry = archive.entry(at: path) else { return nil }
         var data = Data()
         do {
             _ = try archive.extract(entry) { data.append($0) }

--- a/Shared/Sources/Local/LocalFileManager.swift
+++ b/Shared/Sources/Local/LocalFileManager.swift
@@ -228,7 +228,7 @@ extension LocalFileManager {
         bookDir.createDirectory()
         do {
             let archive = try Archive(url: archiveURL, accessMode: .read)
-            guard let entry = EpubParser.entry(in: archive, path: path) else { return nil }
+            guard let entry = archive.entry(at: path) else { return nil }
             _ = try archive.extract(entry, to: fileURL)
             return fileURL
         } catch {

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -357,7 +357,7 @@ class ReaderPageView: UIView {
             do {
                 var data = Data()
                 let archive = try Archive(url: zipURL, accessMode: .read)
-                guard let entry = archive[filePath] else {
+                guard let entry = EpubParser.entry(in: archive, path: filePath) else {
                     return nil
                 }
                 _ = try archive.extract(

--- a/iOS/UI/Reader/Page/ReaderPageView.swift
+++ b/iOS/UI/Reader/Page/ReaderPageView.swift
@@ -357,7 +357,7 @@ class ReaderPageView: UIView {
             do {
                 var data = Data()
                 let archive = try Archive(url: zipURL, accessMode: .read)
-                guard let entry = EpubParser.entry(in: archive, path: filePath) else {
+                guard let entry = archive.entry(at: filePath) else {
                     return nil
                 }
                 _ = try archive.extract(

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -234,6 +234,10 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         pages = paginator.paginate(markdown: text, pageSize: pageSize)
         hasPaginated = true
 
+        // Pagination can produce no pages (e.g. a chapter whose only content is a
+        // failed image reference); bail out before any indexing below
+        guard !pages.isEmpty else { return }
+
         // Update toolbar with our paginated page count
         // ReaderViewController now knows to not switch away when we're already
         // in the paginated text reader with text pages
@@ -335,7 +339,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         do {
             var data = Data()
             let archive = try Archive(url: zipURL, accessMode: .read)
-            guard let entry = archive[filePath] else {
+            guard let entry = EpubParser.entry(in: archive, path: filePath) else {
                 return nil
             }
             _ = try archive.extract(
@@ -418,7 +422,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         guard index >= 0 && index < pages.count else {
             // Return empty view controller as fallback
             let vc = UIViewController()
-            vc.view.backgroundColor = .systemRed
+            vc.view.backgroundColor = .systemBackground
             return vc
         }
 

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -339,7 +339,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         do {
             var data = Data()
             let archive = try Archive(url: zipURL, accessMode: .read)
-            guard let entry = EpubParser.entry(in: archive, path: filePath) else {
+            guard let entry = archive.entry(at: filePath) else {
                 return nil
             }
             _ = try archive.extract(

--- a/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/TextPaginator.swift
@@ -473,8 +473,10 @@ class TextPaginator {
             // only if it's whitespace so we never split a word across pages.
             var breakEnd = sentenceBreak.location + 1
             if breakEnd < text.length {
+                // UnicodeScalar(_: UInt16) is nil for surrogate halves (e.g. emoji);
+                // those are never whitespace, so skip extending the break past them
                 let nextChar = text.character(at: breakEnd)
-                if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(nextChar)!) {
+                if let scalar = UnicodeScalar(nextChar), CharacterSet.whitespacesAndNewlines.contains(scalar) {
                     breakEnd += 1
                 }
             }

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextView.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextView.swift
@@ -44,7 +44,7 @@ struct ReaderTextView: View {
            do {
                var data = Data()
                let archive = try Archive(url: zipURL, accessMode: .read)
-               guard let entry = archive[filePath] else {
+               guard let entry = EpubParser.entry(in: archive, path: filePath) else {
                    return nil
                }
                _ = try archive.extract(

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextView.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextView.swift
@@ -44,7 +44,7 @@ struct ReaderTextView: View {
            do {
                var data = Data()
                let archive = try Archive(url: zipURL, accessMode: .read)
-               guard let entry = EpubParser.entry(in: archive, path: filePath) else {
+               guard let entry = archive.entry(at: filePath) else {
                    return nil
                }
                _ = try archive.extract(

--- a/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Scroll/ReaderTextViewController.swift
@@ -574,7 +574,10 @@ extension ReaderTextViewController {
 
             await MainActor.run {
                 // Add an inline transition view after the last section
-                let lastSection = sections.last!
+                guard let lastSection = sections.last else {
+                    loadingNext = false
+                    return
+                }
                 let screenHeight = transitionPageHeight
                 let tv = createInlineTransitionView(
                     finishedChapter: lastSection.chapter,

--- a/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonPageNode.swift
+++ b/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonPageNode.swift
@@ -443,7 +443,7 @@ extension ReaderWebtoonPageNode {
                 var imageData = Data()
                 let archive: Archive
                 archive = try Archive(url: zipURL, accessMode: .read)
-                guard let entry = archive[filePath]
+                guard let entry = EpubParser.entry(in: archive, path: filePath)
                 else {
                     return nil
                 }

--- a/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonPageNode.swift
+++ b/iOS/UI/Reader/Readers/Webtoon/ReaderWebtoonPageNode.swift
@@ -443,7 +443,7 @@ extension ReaderWebtoonPageNode {
                 var imageData = Data()
                 let archive: Archive
                 archive = try Archive(url: zipURL, accessMode: .read)
-                guard let entry = EpubParser.entry(in: archive, path: filePath)
+                guard let entry = archive.entry(at: filePath)
                 else {
                     return nil
                 }


### PR DESCRIPTION
First step of the text reader stability work discussed in #934 (see my comment https://github.com/Aidoku/Aidoku/issues/934#issuecomment-5131518658): crash and robustness fixes only, no behaviour changes.

## Changes
- Fix a force-unwrap crash in `TextPaginator`'s sentence-break search. The character following a sentence ender is read as a UTF-16 code unit, and `UnicodeScalar(UInt16)` returns nil for surrogate halves, which was force-unwrapped. Any epub containing an emoji near a page break could crash the paged reader.
- Guard against empty pagination results in `ReaderPagedTextViewController.repaginate()` before indexing; the `pages.count - 1` paths could index with -1.
- Replace a `sections.last!` force-unwrap in the scroll reader's `appendNextChapter`.
- Use a neutral background for the paged reader's out-of-range fallback page instead of `.systemRed`.
- Add a tolerant zip entry lookup and use it at the sites that previously read entries with the exact-match subscript, so entries written with a `./` prefix or with percent-encoded paths (common when file names contain spaces or non-ASCII characters) load instead of rendering blank.

## Review feedback
The tolerant lookup was originally added to `EpubParser`. It now lives in `Shared/Extensions/Archive.swift` as `Archive.entry(at:)`, since the behaviour concerns zip entry lookup rather than epub parsing. `EpubParser` calls it through the same extension.

## Testing
- Added the first `TextPaginator` unit tests, including a regression test for the surrogate crash. It crashes the test runner on the previous code and passes with the fix.
- Added `ArchiveTests` covering `entry(at:)`: a `./` prefixed entry, a percent-encoded entry path, case insensitivity, an exact match, and a genuinely absent path. Lookups always arrive decoded, because `EpubParser.resolve(href:relativeTo:)` decodes every href, so the encoded case is a property of the archive rather than of the reference.
- Verified in the simulator with an epub whose entries all carry a `./` prefix. Its image-only chapter renders, which is the path that previously used the exact-match subscript and returned nil.
- Full `AidokuTests` suite passes on the iOS 26.5 simulator, both targets build clean, and there are no new SwiftLint warnings.
