### PR TITLE
fix: correct keyboard navigation on text reader transition pages

### DIFF
--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -357,7 +357,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 
     // MARK: - Navigation
 
-    func move(toPage index: Int, animated: Bool) {
+    func move(toPage index: Int, animated: Bool, direction explicitDirection: UIPageViewController.NavigationDirection? = nil) {
         guard !pages.isEmpty else {
             return
         }
@@ -374,8 +374,12 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 
         let viewController = createPageViewController(for: targetIndex)
 
+        // Moving off a transition page can target the page we're already on,
+        // so the caller supplies the direction in that case
         let direction: UIPageViewController.NavigationDirection
-        if effectiveReadingMode == .rtl {
+        if let explicitDirection {
+            direction = explicitDirection
+        } else if effectiveReadingMode == .rtl {
             direction = targetIndex < oldIndex ? .forward : .reverse
         } else {
             direction = targetIndex > oldIndex ? .forward : .reverse
@@ -450,6 +454,37 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         delegate?.setSliderOffset(offset)
     }
 
+    /// Handle a navigation input while a chapter transition page is displayed.
+    ///
+    /// Transition pages aren't part of `pages`, and `currentPageIndex` still refers to the
+    /// page the reader came from, so the regular index arithmetic lands on the wrong page.
+    /// Returns whether the input was handled.
+    private func handleTransitionPageMove(forward: Bool) -> Bool {
+        guard let currentVC = pageViewController.viewControllers?.first else { return false }
+
+        // a chapter load is already in progress
+        if currentVC is ChapterLoadTriggerViewController {
+            return true
+        }
+
+        guard let transitionVC = currentVC as? ChapterTransitionViewController else { return false }
+
+        // moving in the direction the transition page points at loads that chapter,
+        // moving back returns to the page the transition was reached from
+        if (transitionVC.direction == .next) == forward {
+            guard transitionVC.chapter != nil else { return true }
+            transitionVC.performTransition()
+        } else {
+            guard !pages.isEmpty else { return true }
+            move(
+                toPage: transitionVC.direction == .next ? pages.count - 1 : 0,
+                animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"),
+                direction: forward ? .forward : .reverse
+            )
+        }
+        return true
+    }
+
     // MARK: - Chapter Loading
 
     func loadChapter(_ chapter: AidokuRunner.Chapter, startPage: Int = 0) async {
@@ -497,6 +532,8 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 // MARK: - Reader Delegate
 extension ReaderPagedTextViewController: ReaderReaderDelegate {
     func moveLeft() {
+        guard !handleTransitionPageMove(forward: effectiveReadingMode == .rtl) else { return }
+
         let targetIndex: Int
         switch effectiveReadingMode {
             case .rtl:
@@ -513,6 +550,8 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
     }
 
     func moveRight() {
+        guard !handleTransitionPageMove(forward: effectiveReadingMode != .rtl) else { return }
+
         let targetIndex: Int
         switch effectiveReadingMode {
             case .rtl:

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -357,7 +357,7 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 
     // MARK: - Navigation
 
-    func move(toPage index: Int, animated: Bool, direction explicitDirection: UIPageViewController.NavigationDirection? = nil) {
+    func move(toPage index: Int, animated: Bool) {
         guard !pages.isEmpty else {
             return
         }
@@ -374,12 +374,8 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 
         let viewController = createPageViewController(for: targetIndex)
 
-        // Moving off a transition page can target the page we're already on,
-        // so the caller supplies the direction in that case
         let direction: UIPageViewController.NavigationDirection
-        if let explicitDirection {
-            direction = explicitDirection
-        } else if effectiveReadingMode == .rtl {
+        if effectiveReadingMode == .rtl {
             direction = targetIndex < oldIndex ? .forward : .reverse
         } else {
             direction = targetIndex > oldIndex ? .forward : .reverse
@@ -454,35 +450,36 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         delegate?.setSliderOffset(offset)
     }
 
-    /// Handle a navigation input while a chapter transition page is displayed.
+    /// Navigate to the view controller the data source supplies in the given direction.
     ///
-    /// Transition pages aren't part of `pages`, and `currentPageIndex` still refers to the
-    /// page the reader came from, so the regular index arithmetic lands on the wrong page.
-    /// Returns whether the input was handled.
-    private func handleTransitionPageMove(forward: Bool) -> Bool {
-        guard let currentVC = pageViewController.viewControllers?.first else { return false }
+    /// The data source already accounts for transition pages, which are not part of
+    /// `pages`, so this avoids computing a target from `currentPageIndex`. Bookkeeping
+    /// runs through the same delegate callback a swipe would trigger.
+    private func move(direction: UIPageViewController.NavigationDirection) {
+        guard let currentViewController = pageViewController.viewControllers?.first else { return }
 
-        // a chapter load is already in progress
-        if currentVC is ChapterLoadTriggerViewController {
-            return true
+        let targetViewController = switch direction {
+            case .reverse:
+                pageViewController(pageViewController, viewControllerBefore: currentViewController)
+            default:
+                pageViewController(pageViewController, viewControllerAfter: currentViewController)
         }
+        guard let targetViewController else { return }
 
-        guard let transitionVC = currentVC as? ChapterTransitionViewController else { return false }
-
-        // moving in the direction the transition page points at loads that chapter,
-        // moving back returns to the page the transition was reached from
-        if (transitionVC.direction == .next) == forward {
-            guard transitionVC.chapter != nil else { return true }
-            transitionVC.performTransition()
-        } else {
-            guard !pages.isEmpty else { return true }
-            move(
-                toPage: transitionVC.direction == .next ? pages.count - 1 : 0,
-                animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"),
-                direction: forward ? .forward : .reverse
+        let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
+        pageViewController.setViewControllers(
+            [targetViewController],
+            direction: direction,
+            animated: animated
+        ) { [weak self] completed in
+            guard let self else { return }
+            self.pageViewController(
+                self.pageViewController,
+                didFinishAnimating: true,
+                previousViewControllers: [currentViewController],
+                transitionCompleted: completed
             )
         }
-        return true
     }
 
     // MARK: - Chapter Loading
@@ -532,39 +529,11 @@ class ReaderPagedTextViewController: BaseObservingViewController {
 // MARK: - Reader Delegate
 extension ReaderPagedTextViewController: ReaderReaderDelegate {
     func moveLeft() {
-        guard !handleTransitionPageMove(forward: effectiveReadingMode == .rtl) else { return }
-
-        let targetIndex: Int
-        switch effectiveReadingMode {
-            case .rtl:
-                targetIndex = currentPageIndex + (usesDoublePages ? 2 : 1)
-            default:
-                targetIndex = currentPageIndex - (usesDoublePages ? 2 : 1)
-        }
-
-        if targetIndex >= 0 && targetIndex < pages.count {
-            move(toPage: targetIndex, animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"))
-        } else if targetIndex < 0 {
-            navigateToPreviousChapterTransition()
-        }
+        move(direction: .reverse)
     }
 
     func moveRight() {
-        guard !handleTransitionPageMove(forward: effectiveReadingMode != .rtl) else { return }
-
-        let targetIndex: Int
-        switch effectiveReadingMode {
-            case .rtl:
-                targetIndex = currentPageIndex - (usesDoublePages ? 2 : 1)
-            default:
-                targetIndex = currentPageIndex + (usesDoublePages ? 2 : 1)
-        }
-
-        if targetIndex >= 0 && targetIndex < pages.count {
-            move(toPage: targetIndex, animated: UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions"))
-        } else if targetIndex >= pages.count {
-            navigateToNextChapterTransition()
-        }
+        move(direction: .forward)
     }
 
     func sliderMoved(value: CGFloat) {
@@ -610,66 +579,6 @@ extension ReaderPagedTextViewController: ReaderReaderDelegate {
         Task {
             await loadChapter(chapter, startPage: startPage)
         }
-    }
-
-    /// Navigate toward the previous chapter transition page.
-    /// First call shows the transition info page; second call (when already on it) triggers the chapter load.
-    private func navigateToPreviousChapterTransition() {
-        guard let currentVC = pageViewController.viewControllers?.first else { return }
-        let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
-
-        // Already on the transition page — trigger the chapter load
-        if let transitionVC = currentVC as? ChapterTransitionViewController {
-            guard transitionVC.chapter != nil else { return }
-            transitionVC.performTransition()
-            return
-        }
-
-        // Show the transition page
-        let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
-        let transitionVC = ChapterTransitionViewController(
-            direction: .previous,
-            chapter: previousChapter,
-            currentChapter: chapter,
-            sourceId: sourceId,
-            mangaId: viewModel.manga.key,
-            parentReader: self
-        )
-        pageViewController.setViewControllers(
-            [transitionVC],
-            direction: .reverse,
-            animated: animated
-        )
-    }
-
-    /// Navigate toward the next chapter transition page.
-    /// First call shows the transition info page; second call (when already on it) triggers the chapter load.
-    private func navigateToNextChapterTransition() {
-        guard let currentVC = pageViewController.viewControllers?.first else { return }
-        let animated = UserDefaults.standard.bool(forKey: "Reader.animatePageTransitions")
-
-        // Already on the transition page — trigger the chapter load
-        if let transitionVC = currentVC as? ChapterTransitionViewController {
-            guard transitionVC.chapter != nil else { return }
-            transitionVC.performTransition()
-            return
-        }
-
-        // Show the transition page
-        let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
-        let transitionVC = ChapterTransitionViewController(
-            direction: .next,
-            chapter: nextChapter,
-            currentChapter: chapter,
-            sourceId: sourceId,
-            mangaId: viewModel.manga.key,
-            parentReader: self
-        )
-        pageViewController.setViewControllers(
-            [transitionVC],
-            direction: .forward,
-            animated: animated
-        )
     }
 
     func loadPreviousChapter() {

--- a/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
+++ b/iOS/UI/Reader/Readers/Text/Paged/ReaderPagedTextViewController.swift
@@ -450,11 +450,6 @@ class ReaderPagedTextViewController: BaseObservingViewController {
         delegate?.setSliderOffset(offset)
     }
 
-    /// Navigate to the view controller the data source supplies in the given direction.
-    ///
-    /// The data source already accounts for transition pages, which are not part of
-    /// `pages`, so this avoids computing a target from `currentPageIndex`. Bookkeeping
-    /// runs through the same delegate callback a swipe would trigger.
     private func move(direction: UIPageViewController.NavigationDirection) {
         guard let currentViewController = pageViewController.viewControllers?.first else { return }
 
@@ -485,7 +480,6 @@ class ReaderPagedTextViewController: BaseObservingViewController {
     // MARK: - Chapter Loading
 
     func loadChapter(_ chapter: AidokuRunner.Chapter, startPage: Int = 0) async {
-
         isLoadingChapter = true
         hasPaginated = false
         self.chapter = chapter


### PR DESCRIPTION
Second step of the text reader work from #934: this covers the "keyboard navigation on transition pages doesn't work correctly" item.

## The problem
Chapter transition pages are not part of the paginated `pages` array, so while one is displayed `currentPageIndex` still refers to the page the reader came from. `moveLeft()` and `moveRight()` computed their target by stepping from that stale index, which landed one page off:
- On the next-chapter transition page, moving backward went to the second-to-last page rather than the last one (the case described in the issue).
- On the previous-chapter transition page, moving forward skipped to the second page rather than the first.

Moving toward the adjacent chapter happened to work already, but only because the out-of-range index fell through to a transition helper which then detected it was already on the transition page.

## The fix
Following your review: `moveLeft` and `moveRight` now ask the data source for the adjacent view controller, in the same way `ReaderPagedViewController` does, rather than computing a target index. The data source already resolves every transition case correctly:

- `viewControllerBefore` a next-chapter transition page returns the last text page.
- `viewControllerAfter` a previous-chapter transition page returns the first text page.
- Moving toward the adjacent chapter returns the load trigger page, and the existing `didFinishAnimating` handling performs the transition.
- Either side of the load trigger page returns nil, so input is ignored while a chapter load is in flight.

Because the target now comes from the data source, `navigateToPreviousChapterTransition` and `navigateToNextChapterTransition` have no remaining callers and are removed. They duplicated the transition page construction the data source already performs. The `move` function keeps its original signature; the added `direction` parameter is gone, since nothing computes a target index any more. Keyboard input now takes the same path as a swipe.

Net change against main is 34 lines added and 86 removed, in one file.

Tap zones and the Apple Pencil squeeze gesture route through the same two methods, so they are covered as well.

## Two things left alone
Both are pre-existing and outside this fix, so I have not touched them. Happy to address either separately if you want them.

- `effectiveReadingMode` is hardcoded to `.ltr`, so every `case .rtl` branch in this file is unreachable.
- The text reader has no equivalent of the paged reader's `isTransitioning` re-entrance guard. The data source returning nil for the load trigger page covers the in-flight chapter load this fix concerns, but rapid input during an animation is still unguarded.

## Testing
Verified manually in the paged text reader on the iOS 26.5 simulator, against a multi-chapter epub in the local files source:

- Moving backward off the next-chapter transition page lands on the last page of the chapter, and moving forward off the previous-chapter transition page lands on the first. These are the two cases that were off by one.
- Moving toward the adjacent chapter from either transition page still loads it.
- Input during a chapter load is ignored, with no queued moves and no double advance.
- At the first and last chapters the transition page is shown, and further input in the same direction does nothing.
- Tap zones behave identically to the arrow keys, since both route through `moveLeft` and `moveRight`.
- The animation direction when leaving a transition page is correct in both directions.
- Ordinary page stepping, the slider, and double page mode are unaffected.

Both targets build clean, the full `AidokuTests` suite passes, and there are no new SwiftLint warnings.

Independent of #1033. The two touch different regions of the file and can be merged in either order.
