### PR TITLE
fix: selected cells appear unselected (and reverse)

### DIFF
--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		FB662EEF2DA81A5C00007514 /* MangaCoverPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EE62DA81A5C00007514 /* MangaCoverPageView.swift */; };
 		FB662EF02DA81A5C00007514 /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EE12DA81A5C00007514 /* CloseButton.swift */; };
 		FB662F0A2DA81B8200007514 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662F042DA81B8200007514 /* Shimmer.swift */; };
+		FBA1D0C012340000000000B2 /* RestoreListSelectionOnAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1D0C012340000000000B1 /* RestoreListSelectionOnAppear.swift */; };
 		FBA1D0C012340000000000A2 /* ClearStaleListSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */; };
 		FB662F0D2DA81B8200007514 /* MangaGridButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662F012DA81B8200007514 /* MangaGridButtonStyle.swift */; };
 		FB662F0E2DA81B8200007514 /* AidokuRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EF22DA81B8200007514 /* AidokuRunner.swift */; };
@@ -896,6 +897,7 @@
 		FB662F002DA81B8200007514 /* ListButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListButtonStyle.swift; sourceTree = "<group>"; };
 		FB662F012DA81B8200007514 /* MangaGridButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaGridButtonStyle.swift; sourceTree = "<group>"; };
 		FB662F042DA81B8200007514 /* Shimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shimmer.swift; sourceTree = "<group>"; };
+		FBA1D0C012340000000000B1 /* RestoreListSelectionOnAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreListSelectionOnAppear.swift; sourceTree = "<group>"; };
 		FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearStaleListSelection.swift; sourceTree = "<group>"; };
 		FB662F072DA81B8200007514 /* DownsampleProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownsampleProcessor.swift; sourceTree = "<group>"; };
 		FB67EE5F27F3708400C468EA /* WasmImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WasmImports.swift; sourceTree = "<group>"; };
@@ -1931,6 +1933,7 @@
 				FB261ED22ECA63DA00743F56 /* KeyboardOffsetDetector.swift */,
 				FBAED40D2E3AE5C000B81E74 /* OnReportScrollVisibilityChange.swift */,
 				FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */,
+				FBA1D0C012340000000000B1 /* RestoreListSelectionOnAppear.swift */,
 				FB662F042DA81B8200007514 /* Shimmer.swift */,
 				FB7E441C2F0AB02B005EBCA0 /* InterfaceOrientationsViewModifier.swift */,
 			);
@@ -2646,6 +2649,7 @@
 				FB0E1CD4288AEA8A00B67BA9 /* AniListQueries.swift in Sources */,
 				FBFA43AD2799DD110065A445 /* ReaderSliderView.swift in Sources */,
 				FBA1D0C012340000000000A2 /* ClearStaleListSelection.swift in Sources */,
+				FBA1D0C012340000000000B2 /* RestoreListSelectionOnAppear.swift in Sources */,
 				FB662F0A2DA81B8200007514 /* Shimmer.swift in Sources */,
 				FBF925B82F4F79750049CB43 /* LibraryCategorySelectionHeader.swift in Sources */,
 				FBD7966A2ED270B500BD05F4 /* PageBackground.swift in Sources */,

--- a/Aidoku.xcodeproj/project.pbxproj
+++ b/Aidoku.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		FB662EEF2DA81A5C00007514 /* MangaCoverPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EE62DA81A5C00007514 /* MangaCoverPageView.swift */; };
 		FB662EF02DA81A5C00007514 /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EE12DA81A5C00007514 /* CloseButton.swift */; };
 		FB662F0A2DA81B8200007514 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662F042DA81B8200007514 /* Shimmer.swift */; };
+		FBA1D0C012340000000000A2 /* ClearStaleListSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */; };
 		FB662F0D2DA81B8200007514 /* MangaGridButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662F012DA81B8200007514 /* MangaGridButtonStyle.swift */; };
 		FB662F0E2DA81B8200007514 /* AidokuRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EF22DA81B8200007514 /* AidokuRunner.swift */; };
 		FB662F102DA81B8200007514 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB662EF42DA81B8200007514 /* EdgeInsets.swift */; };
@@ -895,6 +896,7 @@
 		FB662F002DA81B8200007514 /* ListButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListButtonStyle.swift; sourceTree = "<group>"; };
 		FB662F012DA81B8200007514 /* MangaGridButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaGridButtonStyle.swift; sourceTree = "<group>"; };
 		FB662F042DA81B8200007514 /* Shimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shimmer.swift; sourceTree = "<group>"; };
+		FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearStaleListSelection.swift; sourceTree = "<group>"; };
 		FB662F072DA81B8200007514 /* DownsampleProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownsampleProcessor.swift; sourceTree = "<group>"; };
 		FB67EE5F27F3708400C468EA /* WasmImports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WasmImports.swift; sourceTree = "<group>"; };
 		FB67EE6227F3D2E200C468EA /* WasmAidoku.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WasmAidoku.swift; sourceTree = "<group>"; };
@@ -1928,6 +1930,7 @@
 			children = (
 				FB261ED22ECA63DA00743F56 /* KeyboardOffsetDetector.swift */,
 				FBAED40D2E3AE5C000B81E74 /* OnReportScrollVisibilityChange.swift */,
+				FBA1D0C012340000000000A1 /* ClearStaleListSelection.swift */,
 				FB662F042DA81B8200007514 /* Shimmer.swift */,
 				FB7E441C2F0AB02B005EBCA0 /* InterfaceOrientationsViewModifier.swift */,
 			);
@@ -2642,6 +2645,7 @@
 				0C807DDD27D47C2D0042EE7B /* CircularProgressView.swift in Sources */,
 				FB0E1CD4288AEA8A00B67BA9 /* AniListQueries.swift in Sources */,
 				FBFA43AD2799DD110065A445 /* ReaderSliderView.swift in Sources */,
+				FBA1D0C012340000000000A2 /* ClearStaleListSelection.swift in Sources */,
 				FB662F0A2DA81B8200007514 /* Shimmer.swift in Sources */,
 				FBF925B82F4F79750049CB43 /* LibraryCategorySelectionHeader.swift in Sources */,
 				FBD7966A2ED270B500BD05F4 /* PageBackground.swift in Sources */,

--- a/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
+++ b/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
@@ -1,3 +1,10 @@
+//
+//  ClearStaleListSelection.swift
+//  Aidoku
+//
+//  Created by Amqx on 8/6/26.
+//
+
 import SwiftUI
 import SwiftUIIntrospect
 

--- a/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
+++ b/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
@@ -14,12 +14,16 @@ private struct ClearStaleListSelectionModifier<Value: Hashable>: ViewModifier {
 
     @State private var box = CollectionViewBox()
 
+    @Environment(\.listSelectionRestoreState) private var restoreState
+
     func body(content: Content) -> some View {
         content
             .introspect(.list, on: .iOS(.v16, .v17, .v18, .v26, .v27)) { collectionView in
                 box.collectionView = collectionView
             }
             .onChangeWrapper(of: selection) { _, selection in
+                // ignore the empty state a selection restore passes through
+                guard restoreState?.isRestoring != true else { return }
                 guard selection.isEmpty, let collectionView = box.collectionView else { return }
                 for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
                     collectionView.deselectItem(at: indexPath, animated: false)

--- a/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
+++ b/iOS/New/Utilities/Modifiers/ClearStaleListSelection.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import SwiftUIIntrospect
+
+// Use to fix off-screen rows retaining stale selection checkmarks on Lists.
+private struct ClearStaleListSelectionModifier<Value: Hashable>: ViewModifier {
+    let selection: Set<Value>
+
+    @State private var box = CollectionViewBox()
+
+    func body(content: Content) -> some View {
+        content
+            .introspect(.list, on: .iOS(.v16, .v17, .v18, .v26, .v27)) { collectionView in
+                box.collectionView = collectionView
+            }
+            .onChangeWrapper(of: selection) { _, selection in
+                guard selection.isEmpty, let collectionView = box.collectionView else { return }
+                for indexPath in collectionView.indexPathsForSelectedItems ?? [] {
+                    collectionView.deselectItem(at: indexPath, animated: false)
+                }
+            }
+    }
+}
+
+private class CollectionViewBox {
+    weak var collectionView: UICollectionView?
+}
+
+extension View {
+    func clearsStaleListSelection<Value: Hashable>(_ selection: Set<Value>) -> some View {
+        modifier(ClearStaleListSelectionModifier(selection: selection))
+    }
+}

--- a/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
+++ b/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
@@ -1,0 +1,37 @@
+//
+//  RestoreListSelectionOnAppear.swift
+//  Aidoku
+//
+//  Created by Amqx on 8/6/26.
+//
+
+import SwiftUI
+
+// Remove then re-add an entry to force a re-render.
+private struct RestoreListSelectionOnAppearModifier<Value: Hashable>: ViewModifier {
+    @Binding var selection: Set<Value>
+
+    @State private var appeared = false
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                // the first appearance renders from scratch, so there's nothing to restore
+                guard appeared else {
+                    appeared = true
+                    return
+                }
+                guard let value = selection.first else { return }
+                selection.remove(value)
+                DispatchQueue.main.async {
+                    selection.insert(value)
+                }
+            }
+    }
+}
+
+extension View {
+    func restoresListSelectionOnAppear<Value: Hashable>(_ selection: Binding<Set<Value>>) -> some View {
+        modifier(RestoreListSelectionOnAppearModifier(selection: selection))
+    }
+}

--- a/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
+++ b/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
@@ -29,7 +29,7 @@ private struct RestoreListSelectionOnAppearModifier<Value: Hashable>: ViewModifi
                 // look like a deselection and wipe the selection in the backing collection view
                 restoreState.isRestoring = true
                 selection.remove(value)
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     selection.insert(value)
                     restoreState.isRestoring = false
                 }

--- a/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
+++ b/iOS/New/Utilities/Modifiers/RestoreListSelectionOnAppear.swift
@@ -8,13 +8,16 @@
 import SwiftUI
 
 // Remove then re-add an entry to force a re-render.
+// Apply this outside of clearsStaleListSelection, so the transient selection change is ignored there.
 private struct RestoreListSelectionOnAppearModifier<Value: Hashable>: ViewModifier {
     @Binding var selection: Set<Value>
 
     @State private var appeared = false
+    @State private var restoreState = ListSelectionRestoreState()
 
     func body(content: Content) -> some View {
         content
+            .environment(\.listSelectionRestoreState, restoreState)
             .onAppear {
                 // the first appearance renders from scratch, so there's nothing to restore
                 guard appeared else {
@@ -22,11 +25,31 @@ private struct RestoreListSelectionOnAppearModifier<Value: Hashable>: ViewModifi
                     return
                 }
                 guard let value = selection.first else { return }
+                // with a single entry selected the selection is briefly empty, which would otherwise
+                // look like a deselection and wipe the selection in the backing collection view
+                restoreState.isRestoring = true
                 selection.remove(value)
                 DispatchQueue.main.async {
                     selection.insert(value)
+                    restoreState.isRestoring = false
                 }
             }
+    }
+}
+
+// Marks a selection round-trip in progress, so other selection modifiers can ignore it.
+class ListSelectionRestoreState {
+    var isRestoring = false
+}
+
+private struct ListSelectionRestoreStateKey: EnvironmentKey {
+    static let defaultValue: ListSelectionRestoreState? = nil
+}
+
+extension EnvironmentValues {
+    var listSelectionRestoreState: ListSelectionRestoreState? {
+        get { self[ListSelectionRestoreStateKey.self] }
+        set { self[ListSelectionRestoreStateKey.self] = newValue }
     }
 }
 

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -638,6 +638,17 @@ extension MangaView.ViewModel {
 }
 
 extension MangaView.ViewModel {
+    // every chapter row shown in the list, across both sections
+    var listedChapters: [AidokuRunner.Chapter] {
+        chapters + otherDownloadedChapters
+    }
+
+    // resolve selected chapter keys, which can come from either the chapter list
+    // or the separate downloaded chapters section
+    func chapters(forKeys keys: Set<String>) -> [AidokuRunner.Chapter] {
+        listedChapters.filter { keys.contains($0.key) }
+    }
+
     // mark given chapters as read in coredata
     func markRead(chapters: [AidokuRunner.Chapter]) async {
         // only mark chapters that are readable as read

--- a/iOS/New/Views/Manga/MangaView.swift
+++ b/iOS/New/Views/Manga/MangaView.swift
@@ -529,21 +529,23 @@ extension MangaView {
             viewModel: viewModel,
             refreshController: refreshController,
             markAllRead: {
+                let chapters = viewModel.listedChapters
                 // only show loading indicator for a larger number of chapters
-                if viewModel.chapters.count > 100 {
+                if chapters.count > 100 {
                     showLoadingIndicator()
                 }
                 Task {
-                    await viewModel.markRead(chapters: viewModel.chapters)
+                    await viewModel.markRead(chapters: chapters)
                     hideLoadingIndicator()
                 }
             },
             markAllUnread: {
-                if viewModel.chapters.count > 100 {
+                let chapters = viewModel.listedChapters
+                if chapters.count > 100 {
                     showLoadingIndicator()
                 }
                 Task {
-                    await viewModel.markUnread(chapters: viewModel.chapters)
+                    await viewModel.markUnread(chapters: chapters)
                     hideLoadingIndicator()
                 }
             },
@@ -582,12 +584,14 @@ extension MangaView {
 
         ToolbarItem(placement: .topBarLeading) {
             if editMode == .active {
-                let allSelected = selectedChapters.count == viewModel.chapters.count
+                // the downloaded chapters section is selectable too, so it has to be counted here
+                let selectableCount = viewModel.listedChapters.count
+                let allSelected = selectedChapters.count == selectableCount
                 Button {
                     if allSelected {
                         selectedChapters = Set()
                     } else {
-                        selectedChapters = Set(viewModel.chapters.map { $0.key })
+                        selectedChapters = Set(viewModel.listedChapters.map { $0.key })
                     }
                 } label: {
                     if allSelected {
@@ -596,7 +600,7 @@ extension MangaView {
                         Text(NSLocalizedString("SELECT_ALL"))
                     }
                 }
-                .disabled(viewModel.chapters.isEmpty)
+                .disabled(selectableCount == 0)
             }
         }
     }
@@ -640,9 +644,7 @@ extension MangaView {
             }
             Section(title) {
                 Button {
-                    let markChapters = selectedChapters.compactMap { id in
-                        viewModel.chapters.first(where: { $0.key == id })
-                    }
+                    let markChapters = viewModel.chapters(forKeys: selectedChapters)
                     Task {
                         await viewModel.markUnread(chapters: markChapters)
                     }
@@ -653,9 +655,7 @@ extension MangaView {
                     Label(NSLocalizedString("UNREAD"), systemImage: "minus.circle")
                 }
                 Button {
-                    let markChapters = selectedChapters.compactMap { id in
-                        viewModel.chapters.first(where: { $0.key == id })
-                    }
+                    let markChapters = viewModel.chapters(forKeys: selectedChapters)
                     Task {
                         await viewModel.markRead(chapters: markChapters)
                     }

--- a/iOS/New/Views/Manga/MangaView.swift
+++ b/iOS/New/Views/Manga/MangaView.swift
@@ -247,6 +247,7 @@ struct MangaView: View {
                 .navigationTransitionZoom(sourceID: chapter, in: transitionNamespace)
             }
             .environment(\.editMode, $editMode)
+            .clearsStaleListSelection(selectedChapters)
         }
 
         if #available(iOS 26.0, *) {

--- a/iOS/New/Views/Migration/MigrateSelectSeriesView.swift
+++ b/iOS/New/Views/Migration/MigrateSelectSeriesView.swift
@@ -38,6 +38,7 @@ struct MigrateSelectSeriesView: View {
         }
         .environment(\.editMode, $editMode)
         .clearsStaleListSelection(selectedKeys)
+        .restoresListSelectionOnAppear($selectedKeys)
         .navigationTitle(sourceName)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {

--- a/iOS/New/Views/Migration/MigrateSelectSeriesView.swift
+++ b/iOS/New/Views/Migration/MigrateSelectSeriesView.swift
@@ -37,6 +37,7 @@ struct MigrateSelectSeriesView: View {
             }
         }
         .environment(\.editMode, $editMode)
+        .clearsStaleListSelection(selectedKeys)
         .navigationTitle(sourceName)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {


### PR DESCRIPTION
fixes #977 

this appears to be an already identified swift ui bug - see the following: [1](https://developer.apple.com/forums/thread/677802), [2](https://developer.apple.com/forums/thread/682879), and [3](https://developer.apple.com/forums/thread/707333).

from my own testing, this is what i think is happening:
for reproduction 1: when the deselect all call happens, swiftui lazily deselects by only telling uikit to turn off what is visible. when you scroll up, it conveniently forgets to tell uikit to deselect previously unrendered indices.
for reproduction 2: the new view controller detaches the list's host view from the window, then uikit silently drops everything it knows about what was selected. afterwards, when swiftui sends the list back, since the list never changed, it doesn't request a re-render, causing uikit's empty state to get realized.

i have provided 2 bandaids, of which neither are exactly ideal:

- for the series view (unselected looks selected) we manually drain everything out of uikit's memory
- for the migration view (selected looks unselected) we remove then immediately re-add an entry to force a re-render