### PR TITLE
fix: reschedule library refresh after background task completes

### DIFF
--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -397,6 +397,8 @@ extension MangaManager {
 #endif
 
         NotificationCenter.default.post(name: .updateLibrary, object: nil)
+
+        scheduleLibraryRefresh()
     }
 
     /// Check if a manga should skip updating based on skip options.


### PR DESCRIPTION
It looks like the refresh job might not be rescheduling properly, which could be causing library refresh and notifications to break after just one job.
This seems to give more consistent results with notifications.