### PR TITLE
feat: continue reading when reselecting history tab

### DIFF
--- a/Shared/Extensions/NotificationName.swift
+++ b/Shared/Extensions/NotificationName.swift
@@ -40,6 +40,8 @@ extension Notification.Name {
     static let historyAdded = Self("historyAdded")
     static let historyRemoved = Self("historyRemoved")
     static let historySet = Self("historySet")
+    // posted when the history tab is selected while already at the top of the history list
+    static let historyTabReselected = Self("historyTabReselected")
 
     // trackers
     static let updateTrackers = Self("updateTrackers")

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -461,6 +461,7 @@
 "READER" = "Reader";
 "OPEN_READER_VIEW" = "Open Reader View";
 "RESUME_LAST_OPENED_CHAPTER" = "Resume Last Opened Chapter";
+"CONTINUE_READING_ON_RESELECT" = "History Doubleclick Resumes";
 "UNREAD_CHAPTER_BADGES" = "Unread Chapter Badges";
 "DOWNLOADED_CHAPTER_BADGES" = "Downloaded Chapter Badges";
 "PIN_TITLES" = "Pin Titles";

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -461,7 +461,7 @@
 "READER" = "Reader";
 "OPEN_READER_VIEW" = "Open Reader View";
 "RESUME_LAST_OPENED_CHAPTER" = "Resume Last Opened Chapter";
-"CONTINUE_READING_ON_RESELECT" = "History Doubleclick Resumes";
+"CONTINUE_READING_ON_RESELECT" = "History Tab Double Tap Resumes";
 "UNREAD_CHAPTER_BADGES" = "Unread Chapter Badges";
 "DOWNLOADED_CHAPTER_BADGES" = "Downloaded Chapter Badges";
 "PIN_TITLES" = "Pin Titles";

--- a/Shared/Managers/Manga/MangaManager.swift
+++ b/Shared/Managers/Manga/MangaManager.swift
@@ -75,6 +75,73 @@ actor MangaManager {
             return isUnlocked && !isCompleted
         })
     }
+
+    /// Fetches the stored chapters for a manga in the user's sort order, along with the next chapter to read.
+    nonisolated func getNextChapter(
+        sourceKey: String,
+        mangaKey: String,
+        fallbackChapters: [AidokuRunner.Chapter]? = nil,
+        fetchIfNeeded: Bool = false
+    ) async -> (chapters: [AidokuRunner.Chapter], nextChapter: AidokuRunner.Chapter?) {
+        let readingHistory = await CoreDataManager.shared.getReadingHistory(
+            sourceId: sourceKey,
+            mangaId: mangaKey
+        )
+        var chapters = await CoreDataManager.shared.getChapters(sourceId: sourceKey, mangaId: mangaKey)
+            .map { $0.toNew() }
+
+        // chapters are only stored for manga in the library, so fall back to the ones we have loaded
+        if chapters.isEmpty {
+            if let fallbackChapters, !fallbackChapters.isEmpty {
+                chapters = fallbackChapters
+            } else if fetchIfNeeded, let source = SourceManager.shared.source(for: sourceKey) {
+                let manga = AidokuRunner.Manga(sourceKey: sourceKey, key: mangaKey, title: "")
+                let updatedManga = try? await source.getMangaUpdate(
+                    manga: manga,
+                    needsDetails: false,
+                    needsChapters: true
+                )
+                chapters = updatedManga?.chapters ?? []
+            }
+        }
+
+        let filters = await CoreDataManager.shared.container.performBackgroundTask { context in
+            CoreDataManager.shared.getMangaChapterFilters(
+                sourceId: sourceKey,
+                mangaId: mangaKey,
+                context: context
+            )
+        }
+        let sortOption = ChapterSortOption(flags: filters.flags)
+        let sortAscending = filters.flags & ChapterFlagMask.sortAscending != 0
+
+        let sortedChapters: [AidokuRunner.Chapter] = switch sortOption {
+            case .sourceOrder:
+                sortAscending ? chapters.reversed() : chapters
+            case .chapter:
+                chapters.sorted {
+                    let lhs = $0.chapterNumber ?? -1
+                    let rhs = $1.chapterNumber ?? -1
+                    return sortAscending ? lhs < rhs : lhs > rhs
+                }
+            case .uploadDate:
+                chapters.sorted {
+                    let lhs = $0.dateUploaded ?? .distantPast
+                    let rhs = $1.dateUploaded ?? .distantPast
+                    return sortAscending ? lhs < rhs : lhs > rhs
+                }
+        }
+
+        let manga = AidokuRunner.Manga(sourceKey: sourceKey, key: mangaKey, title: "")
+        let nextChapter = getNextChapter(
+            manga: manga,
+            chapters: sortedChapters,
+            readingHistory: readingHistory,
+            sortAscending: sortAscending
+        )
+
+        return (sortedChapters, nextChapter)
+    }
 }
 
 // MARK: - Library Managing

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -127,6 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 "Library.opensReaderView": false,
                 "Library.resumeLastOpenedChapter": false,
+                "Library.continueReadingOnReselect": false,
                 "Library.unreadChapterBadges": true,
                 "Library.downloadedChapterBadges": true,
                 "Library.pinTitles": LibraryViewModel.PinType.none.rawValue,

--- a/iOS/AppDelegate.swift
+++ b/iOS/AppDelegate.swift
@@ -127,7 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
                 "Library.opensReaderView": false,
                 "Library.resumeLastOpenedChapter": false,
-                "Library.continueReadingOnReselect": false,
+                "Library.continueReadingOnReselect": true,
                 "Library.unreadChapterBadges": true,
                 "Library.downloadedChapterBadges": true,
                 "Library.pinTitles": LibraryViewModel.PinType.none.rawValue,

--- a/iOS/Extensions/UIView.swift
+++ b/iOS/Extensions/UIView.swift
@@ -43,6 +43,28 @@ extension UIView {
 }
 
 extension UIView {
+    /// Finds the first scroll view in the view hierarchy, searching depth-first.
+    func firstScrollView() -> UIScrollView? {
+        if let scrollView = self as? UIScrollView {
+            return scrollView
+        }
+        for subview in subviews {
+            if let scrollView = subview.firstScrollView() {
+                return scrollView
+            }
+        }
+        return nil
+    }
+}
+
+extension UIScrollView {
+    /// Whether the scroll view is scrolled to the top of its content.
+    var isScrolledToTop: Bool {
+        contentOffset.y <= -adjustedContentInset.top + 1
+    }
+}
+
+extension UIView {
     func forceNoClip() {
         let originalClass: AnyClass = object_getClass(self)!
         let subclassName = "\(originalClass)_ClipsToBoundsSwizzled_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"

--- a/iOS/New/Views/History/HistoryView.swift
+++ b/iOS/New/Views/History/HistoryView.swift
@@ -25,6 +25,8 @@ struct HistoryView: View {
 
     @State private var listSelection: String? // fix for list highlighting being buggy
 
+    @State private var openingLastRead = false
+
     @EnvironmentObject private var path: NavigationCoordinator
 
     var body: some View {
@@ -141,6 +143,12 @@ struct HistoryView: View {
             // lock the view when the app is backgrounded
             locked = UserDefaults.standard.bool(forKey: "History.lockHistoryTab")
         }
+        .onReceive(NotificationCenter.default.publisher(for: .historyTabReselected)) { _ in
+            // the history tab was selected while already at the top of the list
+            Task {
+                await continueReading()
+            }
+        }
     }
 
     var lockedView: some View {
@@ -245,6 +253,74 @@ struct HistoryView: View {
                 await viewModel.loadMore()
             }
         }
+    }
+
+    // open the most recently read manga, resuming from the chapter it left off on
+    @MainActor
+    func continueReading() async {
+        guard !locked, !openingLastRead else { return }
+        openingLastRead = true
+        defer { openingLastRead = false }
+
+        let entry = await CoreDataManager.shared.container.performBackgroundTask { context in
+            CoreDataManager.shared.getRecentHistory(limit: 1, offset: 0, context: context)
+                .first
+                .map { (sourceId: $0.sourceId, mangaId: $0.mangaId) }
+        }
+        guard let entry else { return }
+
+        let mangaCacheKey = "\(entry.sourceId).\(entry.mangaId)"
+        var manga = viewModel.mangaCache[mangaCacheKey]
+        if manga == nil {
+            manga = await CoreDataManager.shared.container.performBackgroundTask { context in
+                CoreDataManager.shared.getManga(
+                    sourceId: entry.sourceId,
+                    mangaId: entry.mangaId,
+                    context: context
+                )?.toNewManga()
+            }
+        }
+
+        let (chapters, nextChapter) = await MangaManager.shared.getNextChapter(
+            sourceKey: entry.sourceId,
+            mangaKey: entry.mangaId,
+            fallbackChapters: manga?.chapters,
+            fetchIfNeeded: true
+        )
+
+        var targetManga = manga ?? AidokuRunner.Manga(sourceKey: entry.sourceId, key: entry.mangaId, title: "")
+        if !chapters.isEmpty {
+            targetManga.chapters = chapters
+        }
+
+        // the user can navigate elsewhere while the chapters are loading
+        guard
+            let rootViewController = path.rootViewController,
+            rootViewController.view.window != nil,
+            rootViewController.navigationController?.topViewController === rootViewController
+        else { return }
+
+        guard
+            let chapter = nextChapter,
+            let source = SourceManager.shared.source(for: entry.sourceId)
+        else {
+            // nothing left to read (or the source is missing), so open the manga page instead.
+            // without a source to load details from or anything stored to show, the page would be blank
+            guard
+                SourceManager.shared.hasSourceInstalled(id: entry.sourceId) || !targetManga.title.isEmpty
+            else { return }
+            path.push(MangaViewController(manga: targetManga, parent: rootViewController))
+            return
+        }
+
+        let readerController = ReaderViewController(
+            source: source,
+            manga: targetManga,
+            chapter: chapter
+        )
+        let navigationController = ReaderNavigationController(readerViewController: readerController)
+        navigationController.modalPresentationStyle = .fullScreen
+        path.present(navigationController)
     }
 
     // prompt for biometrics to unlock the view

--- a/iOS/New/Views/History/HistoryView.swift
+++ b/iOS/New/Views/History/HistoryView.swift
@@ -256,7 +256,6 @@ struct HistoryView: View {
     }
 
     // open the most recently read manga, resuming from the chapter it left off on
-    @MainActor
     func continueReading() async {
         guard !locked, !openingLastRead else { return }
         openingLastRead = true

--- a/iOS/New/Views/Settings/Settings.swift
+++ b/iOS/New/Views/Settings/Settings.swift
@@ -182,6 +182,11 @@ extension Settings {
                 value: .toggle(.init())
             ),
             .init(
+                key: "Library.continueReadingOnReselect",
+                title: NSLocalizedString("CONTINUE_READING_ON_RESELECT"),
+                value: .toggle(.init())
+            ),
+            .init(
                 key: "Library.unreadChapterBadges",
                 title: NSLocalizedString("UNREAD_CHAPTER_BADGES"),
                 value: .toggle(.init())

--- a/iOS/UI/Common/TabBarController.swift
+++ b/iOS/UI/Common/TabBarController.swift
@@ -17,6 +17,8 @@ class TabBarController: UITabBarController {
     private var settingsPath: NavigationCoordinator?
     private var previousSelectedIndex: Int?
 
+    private weak var historyNavigationController: UINavigationController?
+
     private lazy var libraryProgressView = CircularProgressView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
 
     private lazy var libraryRefreshAccessory: UIView = {
@@ -78,6 +80,7 @@ class TabBarController: UITabBarController {
             .environmentObject(historyPath))
         historyPath.rootViewController = historyHostingController
         let historyViewController = NavigationController(rootViewController: historyHostingController)
+        historyNavigationController = historyViewController
 
         let settingsPath = NavigationCoordinator(rootViewController: nil)
         let settingsViewController: UIViewController
@@ -291,6 +294,37 @@ extension TabBarController: UITabBarControllerDelegate {
         if #unavailable(iOS 18.0) {
             checkForSettingsPop()
         }
+    }
+
+    @available(iOS 18.0, *)
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelectTab tab: UITab) -> Bool {
+        if tab === tabBarController.selectedTab {
+            checkForHistoryReselection()
+        }
+        return true
+    }
+
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        if viewController === selectedViewController {
+            checkForHistoryReselection()
+        }
+        return true
+    }
+
+    // when the history tab is selected while it's already showing the top of the history list,
+    // let the history view know so that it can continue reading the last opened manga
+    private func checkForHistoryReselection() {
+        guard
+            UserDefaults.standard.bool(forKey: "Library.continueReadingOnReselect"),
+            let historyNavigationController,
+            selectedViewController === historyNavigationController,
+            // if there's anything pushed on top, the default behavior pops back to the history list
+            historyNavigationController.viewControllers.count == 1,
+            // if the list isn't at the top, the default behavior scrolls it there
+            let scrollView = historyNavigationController.topViewController?.view.firstScrollView(),
+            scrollView.isScrolledToTop
+        else { return }
+        NotificationCenter.default.post(name: .historyTabReselected, object: nil)
     }
 
     private func checkForSettingsPop() {

--- a/iOS/UI/Library/LibraryViewController.swift
+++ b/iOS/UI/Library/LibraryViewController.swift
@@ -1296,51 +1296,9 @@ extension LibraryViewController {
         if UserDefaults.standard.bool(forKey: "Library.opensReaderView") {
             Task {
                 // get next chapter to read
-                let history = await CoreDataManager.shared.getReadingHistory(
-                    sourceId: info.sourceId,
-                    mangaId: info.mangaId
-                )
-                let chapters = await CoreDataManager.shared.getChapters(sourceId: info.sourceId, mangaId: info.mangaId)
-                    .map { $0.toNew() }
-
-                let filters = CoreDataManager.shared.getMangaChapterFilters(
-                    sourceId: info.sourceId,
-                    mangaId: info.mangaId
-                )
-                let sortOption = ChapterSortOption(flags: filters.flags)
-                let sortAscending = filters.flags & ChapterFlagMask.sortAscending != 0
-
-                let sortedChapters: [AidokuRunner.Chapter] = {
-                    switch sortOption {
-                        case .sourceOrder:
-                            return sortAscending ? chapters.reversed() : chapters
-                        case .chapter:
-                            return chapters.sorted {
-                                let lhs = $0.chapterNumber ?? -1
-                                let rhs = $1.chapterNumber ?? -1
-                                return sortAscending ? lhs < rhs : lhs > rhs
-                            }
-                        case .uploadDate:
-                            return chapters.sorted {
-                                let lhs = $0.dateUploaded ?? .distantPast
-                                let rhs = $1.dateUploaded ?? .distantPast
-                                return sortAscending ? lhs < rhs : lhs > rhs
-                            }
-                    }
-                }()
-
-                let manga = AidokuRunner.Manga(
+                let (sortedChapters, nextChapter) = await MangaManager.shared.getNextChapter(
                     sourceKey: info.sourceId,
-                    key: info.mangaId,
-                    title: info.title ?? "",
-                    chapters: sortedChapters
-                )
-
-                let nextChapter = MangaManager.shared.getNextChapter(
-                    manga: manga,
-                    chapters: sortedChapters,
-                    readingHistory: history,
-                    sortAscending: sortAscending
+                    mangaKey: info.mangaId
                 )
 
                 if let chapter = nextChapter {


### PR DESCRIPTION
when the history tab is reselected the following behaviour now occurs

1. (existing) if not in full history list (ie inside a specific manga) return to history list
2. (existing) if not at top of history list return to top of history list
3. (new) if at top of full history list, resume reading last read series

this is guarded by a setting in library that defaults to false, so users have to opt-in