### PR TITLE
Fix Cloudflare challenges never clearing on iPad

### DIFF
--- a/Shared/Utilities/CloudflareHandler.swift
+++ b/Shared/Utilities/CloudflareHandler.swift
@@ -154,19 +154,7 @@ actor CloudflareHandler: NSObject {
     private func addWebView(for request: URLRequest) async -> Bool {
         guard let parentView else { return false }
 
-        // Keep the rendering mode CONSISTENT with the user agent this view is about to claim.
-        //
-        // On iPad the default (.recommended) renders desktop-class, so navigator.platform reports
-        // "MacIntel" while customUserAgent below still says "iPad ... Mobile/15E148". No real
-        // browser emits that pair: iPad Safari is either a Macintosh UA with MacIntel (its default)
-        // or an iPad UA with iPad ("Request Mobile Website"). Turnstile fingerprints exactly this
-        // kind of contradiction, so iPad always drew the interactive challenge and solving it never
-        // produced a usable clearance.
-        //
-        // Scoped to a mobile user agent rather than forced unconditionally: Aidoku also builds for
-        // macOS and visionOS, where the claimed UA is a desktop one and .recommended is already the
-        // consistent choice. Forcing .mobile there would introduce the mirror image of this bug.
-        // iPhone already reports platform "iPhone", so this is a no-op there too.
+        // match web view rendering mode with user agent
         let userAgent = request.value(forHTTPHeaderField: "User-Agent")
         let config = WKWebViewConfiguration()
         if let userAgent, userAgent.contains("iPhone") || userAgent.contains("iPad") {

--- a/Shared/Utilities/CloudflareHandler.swift
+++ b/Shared/Utilities/CloudflareHandler.swift
@@ -154,9 +154,27 @@ actor CloudflareHandler: NSObject {
     private func addWebView(for request: URLRequest) async -> Bool {
         guard let parentView else { return false }
 
-        webView = WKWebView(frame: .zero)
+        // Keep the rendering mode CONSISTENT with the user agent this view is about to claim.
+        //
+        // On iPad the default (.recommended) renders desktop-class, so navigator.platform reports
+        // "MacIntel" while customUserAgent below still says "iPad ... Mobile/15E148". No real
+        // browser emits that pair: iPad Safari is either a Macintosh UA with MacIntel (its default)
+        // or an iPad UA with iPad ("Request Mobile Website"). Turnstile fingerprints exactly this
+        // kind of contradiction, so iPad always drew the interactive challenge and solving it never
+        // produced a usable clearance.
+        //
+        // Scoped to a mobile user agent rather than forced unconditionally: Aidoku also builds for
+        // macOS and visionOS, where the claimed UA is a desktop one and .recommended is already the
+        // consistent choice. Forcing .mobile there would introduce the mirror image of this bug.
+        // iPhone already reports platform "iPhone", so this is a no-op there too.
+        let userAgent = request.value(forHTTPHeaderField: "User-Agent")
+        let config = WKWebViewConfiguration()
+        if let userAgent, userAgent.contains("iPhone") || userAgent.contains("iPad") {
+            config.defaultWebpagePreferences.preferredContentMode = .mobile
+        }
+        webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = await proxy(for: request)
-        webView.customUserAgent = request.value(forHTTPHeaderField: "User-Agent")
+        webView.customUserAgent = userAgent
         webView.translatesAutoresizingMaskIntoConstraints = false
         parentView.addSubview(webView)
 


### PR DESCRIPTION
## Summary

On iPad, Cloudflare-protected sources get stuck in a loop: the challenge sheet
appears, you solve it, and the request fails anyway. The same source on the same
network, same iOS version and same Aidoku build works on iPhone.

The cause is in `CloudflareHandler.addWebView`. The challenge web view sets
`customUserAgent` to the request's user agent, which on iPad is the mobile
string:

```
Mozilla/5.0 (iPad; CPU OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
```

The view is created without a configuration, though, so `preferredContentMode`
stays `.recommended`. On iPad that renders desktop class, and
`navigator.platform` reports `MacIntel`.

No real browser produces that combination. iPad Safari gives you either a
Macintosh user agent with `MacIntel`, which is the default, or an iPad user agent
with `iPad` under "Request Mobile Website". Turnstile fingerprints exactly this
sort of inconsistency, which is why the iPad reliably drew the interactive
challenge and why solving it never helped: the contradiction was still there on
the next request.

iPhone escapes all of this because its user agent and platform already agree.

## The fix

Keep the rendering mode consistent with the user agent the view is about to
claim:

```swift
let userAgent = request.value(forHTTPHeaderField: "User-Agent")
let config = WKWebViewConfiguration()
if let userAgent, userAgent.contains("iPhone") || userAgent.contains("iPad") {
    config.defaultWebpagePreferences.preferredContentMode = .mobile
}
webView = WKWebView(frame: .zero, configuration: config)
webView.navigationDelegate = await proxy(for: request)
webView.customUserAgent = userAgent
```

The goal is consistency between the two, so the check is deliberately scoped to
mobile user agents. `SUPPORTED_PLATFORMS` includes `macosx` and `xros`, where the
claimed user agent is a desktop one and `.recommended` is already the matching
choice. Forcing `.mobile` there would create the same bug in reverse.

## Measurements

A probe reproducing `addWebView`'s construction, sampled after page load, 10
samples per device:

| | iPad Pro 13-inch | iPhone 17 Pro |
| --- | --- | --- |
| user agent sent | `(iPad; CPU OS 18_7 ...) ... Mobile/15E148` | `(iPhone; ...) ... Mobile/15E148` |
| `navigator.platform` before | `MacIntel` (10/10) | `iPhone` (10/10) |
| `navigator.platform` after | `iPad` (10/10) | `iPhone` (10/10, unchanged) |
| `preferredContentMode` before | 0 (`.recommended`) | 0 (`.recommended`) |

One trap worth knowing if you reproduce this: `navigator.platform` still reads
`iPad` if you query it the instant `readyState` hits `complete`. iPadOS switches
to desktop class a moment later. A single early sample will tell you there is no
bug.

## Behaviour

Four Cloudflare-protected sources on four different origins, each opened on iPad
with the app's stored clearance wiped to force a cold challenge. All four load on
the first attempt with no errors, and the challenge handler ran every time, so
these were genuine challenges rather than runs where Cloudflare stayed quiet:

- kagane.to, which used to loop the turnstile
- mangadot.net
- comix.to
- onisaga.com

If the shared challenge view were not the cause, one configuration change would
not clear four independent origins at once.

I hit this for months across multiple iPads, and confirmed the fix on real
hardware before opening this.

## Scope

Only the hidden challenge web view changes. The app builds five other
`WKWebView`s: the user agent probe, the settings web view, the dictionary popup,
the OIDC login controller and the reader. None of them are touched. The challenge
view never renders content to the user, so nothing changes visually.

## Caveats

- The platform measurements come from the iOS Simulator (iPad Pro 13-inch and
  iPhone 17 Pro, iOS 26.5). Real hardware confirms the outcome, that sources load
  and the loop stops, but not the `navigator.platform` figures.
- Untested on macOS and visionOS. The scoping leaves those paths exactly as they
  are today, which seemed safer than assuming someone would retest them.
- Cloudflare's fingerprinting is inferred from behaviour rather than observed
  from their side. The evidence is consistent: with the contradiction present the
  challenge is interactive and never clears, and removing it gives a clean pass
  across four origins. It is still inference about a third party's detection.
