### PR TITLE
fix: keep incomplete downloads in a failed state

### DIFF
--- a/AidokuTests/PartialDownloadTests.swift
+++ b/AidokuTests/PartialDownloadTests.swift
@@ -54,39 +54,6 @@ struct PartialDownloadTests {
         #expect(DownloadManager.shared.getDownloadStatus(for: chapter) == .finished)
     }
 
-    /// A retry refetches every page and the extension comes from the response, so anything the
-    /// failed attempt left behind has to go or the chapter can end up holding a page twice.
-    @Test func discardingAFailedDownloadTakesItsPagesWithIt() throws {
-        let cache = DownloadCache()
-        let chapter = identifier("discarded")
-        defer { removeDirectories(for: chapter) }
-
-        let tmpDirectory = cache.tmpDirectory(for: chapter)
-        tmpDirectory.createDirectory()
-        try Data().write(to: tmpDirectory.appendingPathComponent("001.png"))
-        try Data("[2]".utf8).write(to: cache.failureMarker(inTmpDirectory: tmpDirectory))
-
-        cache.discardFailedDownload(for: chapter)
-
-        #expect(!tmpDirectory.exists)
-    }
-
-    /// Only a failed download is discarded: the same directory shape belongs to a download that is
-    /// still running, and removing that would cancel it.
-    @Test func discardingLeavesAnUnmarkedStagingDirectoryAlone() throws {
-        let cache = DownloadCache()
-        let chapter = identifier("running")
-        defer { removeDirectories(for: chapter) }
-
-        let tmpDirectory = cache.tmpDirectory(for: chapter)
-        tmpDirectory.createDirectory()
-        try Data().write(to: tmpDirectory.appendingPathComponent("001.png"))
-
-        cache.discardFailedDownload(for: chapter)
-
-        #expect(tmpDirectory.exists)
-    }
-
     /// The marker lives inside the staging directory, so discarding a failed download stays a
     /// single removal and nothing is left beside it.
     @Test func markerLivesInsideTheStagingDirectory() {

--- a/AidokuTests/PartialDownloadTests.swift
+++ b/AidokuTests/PartialDownloadTests.swift
@@ -1,0 +1,114 @@
+//
+//  PartialDownloadTests.swift
+//  Aidoku
+//
+//  Created by Pietro Baiguini on 8/20/26.
+//
+
+@testable import Aidoku
+import Foundation
+import Testing
+
+/// A download that stops with pages missing and one that is still running are both a staging
+/// directory on disk, and only the failure marker tells them apart. These cover that distinction,
+/// which is what a chapter being reported as downloaded while incomplete turned on.
+@MainActor
+struct PartialDownloadTests {
+    @Test func reportsNoneWithoutAnyDirectory() {
+        let chapter = identifier("none")
+        defer { removeDirectories(for: chapter) }
+
+        #expect(DownloadManager.shared.getDownloadStatus(for: chapter) == DownloadStatus.none)
+    }
+
+    @Test func reportsQueuedForUnmarkedStagingDirectory() {
+        let cache = DownloadCache()
+        let chapter = identifier("queued")
+        defer { removeDirectories(for: chapter) }
+
+        cache.tmpDirectory(for: chapter).createDirectory()
+
+        #expect(DownloadManager.shared.getDownloadStatus(for: chapter) == .queued)
+    }
+
+    @Test func reportsFailedForMarkedStagingDirectory() throws {
+        let cache = DownloadCache()
+        let chapter = identifier("failed")
+        defer { removeDirectories(for: chapter) }
+
+        let tmpDirectory = cache.tmpDirectory(for: chapter)
+        tmpDirectory.createDirectory()
+        try Data("[3,7]".utf8).write(to: cache.failureMarker(inTmpDirectory: tmpDirectory))
+
+        #expect(cache.hasFailureMarker(inTmpDirectory: tmpDirectory))
+        #expect(DownloadManager.shared.getDownloadStatus(for: chapter) == .failed)
+    }
+
+    @Test func reportsFinishedForChapterDirectory() {
+        let cache = DownloadCache()
+        let chapter = identifier("finished")
+        defer { removeDirectories(for: chapter) }
+
+        cache.directory(for: chapter).createDirectory()
+
+        #expect(DownloadManager.shared.getDownloadStatus(for: chapter) == .finished)
+    }
+
+    /// A retry refetches every page and the extension comes from the response, so anything the
+    /// failed attempt left behind has to go or the chapter can end up holding a page twice.
+    @Test func discardingAFailedDownloadTakesItsPagesWithIt() throws {
+        let cache = DownloadCache()
+        let chapter = identifier("discarded")
+        defer { removeDirectories(for: chapter) }
+
+        let tmpDirectory = cache.tmpDirectory(for: chapter)
+        tmpDirectory.createDirectory()
+        try Data().write(to: tmpDirectory.appendingPathComponent("001.png"))
+        try Data("[2]".utf8).write(to: cache.failureMarker(inTmpDirectory: tmpDirectory))
+
+        cache.discardFailedDownload(for: chapter)
+
+        #expect(!tmpDirectory.exists)
+    }
+
+    /// Only a failed download is discarded: the same directory shape belongs to a download that is
+    /// still running, and removing that would cancel it.
+    @Test func discardingLeavesAnUnmarkedStagingDirectoryAlone() throws {
+        let cache = DownloadCache()
+        let chapter = identifier("running")
+        defer { removeDirectories(for: chapter) }
+
+        let tmpDirectory = cache.tmpDirectory(for: chapter)
+        tmpDirectory.createDirectory()
+        try Data().write(to: tmpDirectory.appendingPathComponent("001.png"))
+
+        cache.discardFailedDownload(for: chapter)
+
+        #expect(tmpDirectory.exists)
+    }
+
+    /// The marker lives inside the staging directory, so discarding a failed download stays a
+    /// single removal and nothing is left beside it.
+    @Test func markerLivesInsideTheStagingDirectory() {
+        let cache = DownloadCache()
+        let chapter = identifier("contained")
+        defer { removeDirectories(for: chapter) }
+
+        let tmpDirectory = cache.tmpDirectory(for: chapter)
+
+        let marker = cache.failureMarker(inTmpDirectory: tmpDirectory)
+
+        #expect(marker.deletingLastPathComponent().path == tmpDirectory.path)
+    }
+}
+
+private extension PartialDownloadTests {
+    // each test gets its own manga so that a leftover directory cannot affect another
+    func identifier(_ name: String) -> ChapterIdentifier {
+        .init(sourceKey: "test.partial-download", mangaKey: name, chapterKey: "1")
+    }
+
+    func removeDirectories(for chapter: ChapterIdentifier) {
+        DownloadCache().directory(for: chapter.mangaIdentifier).removeItem()
+    }
+}

--- a/Shared/Data/Downloads/DownloadCache.swift
+++ b/Shared/Data/Downloads/DownloadCache.swift
@@ -142,35 +142,15 @@ extension DownloadCache {
             .appendingSafePathComponent("\(Self.tmpDirectoryPrefix)\(chapter.chapterKey)")
     }
 
-    /// Marks a staging directory as a download that finished with pages missing.
-    ///
-    /// A partial failure and a download still in progress are otherwise identical on disk: both are
-    /// a `.tmp` directory holding some of the pages, so without this a failed chapter would report
-    /// itself queued for ever. The marker names the pages that failed, which is what a later resume
-    /// would need to refetch only those.
-    ///
-    /// It is inside the staging directory rather than beside it so that discarding the download is
-    /// still one `removeItem`, and it is named so that it cannot be mistaken for a page: pages are
-    /// `%03d` with an image extension.
+    // marker file for failed downloads, which is contained inside a .tmp directory
+    nonisolated static let failureMarkerName = ".failed"
+
     nonisolated func failureMarker(inTmpDirectory directory: URL) -> URL {
         directory.appendingPathComponent(Self.failureMarkerName)
     }
 
-    nonisolated static let failureMarkerName = ".failed"
-
     /// Whether a staging directory holds a download that failed rather than one still running.
     nonisolated func hasFailureMarker(inTmpDirectory directory: URL) -> Bool {
         failureMarker(inTmpDirectory: directory).exists
-    }
-
-    /// Discards whatever a previous attempt left behind for a chapter that failed.
-    ///
-    /// A retry refetches every page, and the extension a page is stored under comes from its
-    /// response, so a page arriving as a jpeg where it was a png before would leave both files in
-    /// place and the chapter would end up showing that page twice.
-    nonisolated func discardFailedDownload(for chapter: ChapterIdentifier) {
-        let directory = tmpDirectory(for: chapter)
-        guard hasFailureMarker(inTmpDirectory: directory) else { return }
-        directory.removeItem()
     }
 }

--- a/Shared/Data/Downloads/DownloadCache.swift
+++ b/Shared/Data/Downloads/DownloadCache.swift
@@ -132,10 +132,45 @@ extension DownloadCache {
             .appendingSafePathComponent(chapter.chapterKey)
     }
 
+    /// Prefix of the directory a chapter is downloaded into before it is promoted to a chapter.
+    nonisolated static let tmpDirectoryPrefix = ".tmp_"
+
     nonisolated func tmpDirectory(for chapter: ChapterIdentifier) -> URL {
         DownloadManager.directory
             .appendingSafePathComponent(chapter.sourceKey)
             .appendingSafePathComponent(chapter.mangaKey)
-            .appendingSafePathComponent(".tmp_\(chapter.chapterKey)")
+            .appendingSafePathComponent("\(Self.tmpDirectoryPrefix)\(chapter.chapterKey)")
+    }
+
+    /// Marks a staging directory as a download that finished with pages missing.
+    ///
+    /// A partial failure and a download still in progress are otherwise identical on disk: both are
+    /// a `.tmp` directory holding some of the pages, so without this a failed chapter would report
+    /// itself queued for ever. The marker names the pages that failed, which is what a later resume
+    /// would need to refetch only those.
+    ///
+    /// It is inside the staging directory rather than beside it so that discarding the download is
+    /// still one `removeItem`, and it is named so that it cannot be mistaken for a page: pages are
+    /// `%03d` with an image extension.
+    nonisolated func failureMarker(inTmpDirectory directory: URL) -> URL {
+        directory.appendingPathComponent(Self.failureMarkerName)
+    }
+
+    nonisolated static let failureMarkerName = ".failed"
+
+    /// Whether a staging directory holds a download that failed rather than one still running.
+    nonisolated func hasFailureMarker(inTmpDirectory directory: URL) -> Bool {
+        failureMarker(inTmpDirectory: directory).exists
+    }
+
+    /// Discards whatever a previous attempt left behind for a chapter that failed.
+    ///
+    /// A retry refetches every page, and the extension a page is stored under comes from its
+    /// response, so a page arriving as a jpeg where it was a png before would leave both files in
+    /// place and the chapter would end up showing that page twice.
+    nonisolated func discardFailedDownload(for chapter: ChapterIdentifier) {
+        let directory = tmpDirectory(for: chapter)
+        guard hasFailureMarker(inTmpDirectory: directory) else { return }
+        directory.removeItem()
     }
 }

--- a/Shared/Data/Downloads/DownloadManager.swift
+++ b/Shared/Data/Downloads/DownloadManager.swift
@@ -143,8 +143,6 @@ actor DownloadManager {
         } else {
             let tmpDirectory = cache.tmpDirectory(for: chapter)
             if tmpDirectory.exists {
-                // A staging directory is either a download in progress or one that finished with
-                // pages missing, and only the marker tells them apart.
                 return cache.hasFailureMarker(inTmpDirectory: tmpDirectory) ? .failed : .queued
             } else {
                 return .none
@@ -230,25 +228,22 @@ extension DownloadManager {
         for chapter in chapters {
             let directory = cache.directory(for: chapter)
             let archiveURL = directory.appendingPathExtension("cbz")
-            // a download that finished with pages missing leaves a marked staging directory instead
-            // of a chapter, and removing it is the only way back out of the failed state
             let tmpDirectory = cache.tmpDirectory(for: chapter)
-            let failedDirectory = cache.hasFailureMarker(inTmpDirectory: tmpDirectory) ? tmpDirectory : nil
-            if directory.exists || archiveURL.exists || failedDirectory != nil {
+
+            if directory.exists || archiveURL.exists || tmpDirectory.exists {
                 directory.removeItem()
                 archiveURL.removeItem()
-                failedDirectory?.removeItem()
+                tmpDirectory.removeItem()
                 await cache.remove(chapter: chapter)
 
                 // check if all chapters have been removed (then remove manga directory)
                 let manga = chapter.mangaIdentifier
-                // a failed download counts as remaining, otherwise removing one of them takes the
-                // whole manga directory with it and the rest go silently
                 let hasRemainingChapters = cache.directory(for: manga)
                     .contentsIncludingHidden
                     .contains {
                         guard $0.isDirectory || $0.pathExtension == "cbz" else { return false }
                         guard $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) else { return true }
+                        // a failed download counts as remaining
                         return cache.hasFailureMarker(inTmpDirectory: $0)
                     }
                 if !hasRemainingChapters {
@@ -365,9 +360,7 @@ extension DownloadManager {
             for mangaDirectory in mangaDirectories {
                 let mangaId = mangaDirectory.lastPathComponent
 
-                // Count chapters and calculate total size. A download that stopped with pages
-                // missing counts too, so that a manga holding only those still appears here and
-                // can be removed.
+                // Count chapters and calculate total size, including from failed downloads
                 let chapterDirectories = mangaDirectory.contentsIncludingHidden.filter {
                     guard $0.isDirectory || $0.pathExtension == "cbz" else { return false }
                     guard $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) else { return true }
@@ -376,8 +369,6 @@ extension DownloadManager {
 
                 guard !chapterDirectories.isEmpty else { continue }
 
-                // hidden entries are counted so that a failed download, which is listed above,
-                // contributes the space it occupies rather than going unaccounted for
                 let totalSize = await calculateDirectorySize(mangaDirectory, includingHidden: true)
                 let chapterCount = chapterDirectories.count
 
@@ -485,16 +476,14 @@ extension DownloadManager {
         let chapterDirectories = mangaDirectory.contents.filter {
             ($0.isDirectory || $0.pathExtension == "cbz") && !$0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix)
         }
-        // a download that stopped with pages missing never leaves its staging directory, and is
-        // listed here as well: otherwise it takes up space that nothing on screen accounts for
         let failedDirectories = mangaDirectory.contentsIncludingHidden.filter {
             $0.isDirectory && cache.hasFailureMarker(inTmpDirectory: $0)
         }
 
         var chapters: [DownloadedChapterInfo] = []
+        let entries = chapterDirectories.map { ($0, false) } + failedDirectories.map { ($0, true) }
 
-        for chapterDirectory in chapterDirectories + failedDirectories {
-            let failed = failedDirectories.contains(chapterDirectory)
+        for (chapterDirectory, failed) in entries {
             let chapterId = if failed {
                 String(chapterDirectory.lastPathComponent.dropFirst(DownloadCache.tmpDirectoryPrefix.count))
             } else {
@@ -524,15 +513,13 @@ extension DownloadManager {
         }
 
         // Sort chapters by ID
-        chapters.sort { lhs, rhs in
+        return chapters.sorted { lhs, rhs in
             // Try to sort numerically if possible, otherwise alphabetically
             if let lhsNum = Double(lhs.chapterId), let rhsNum = Double(rhs.chapterId) {
                 return lhsNum < rhsNum
             }
             return lhs.chapterId.localizedStandardCompare(rhs.chapterId) == .orderedAscending
         }
-
-        return chapters
     }
 
     /// Save chapter metadata to ComicInfo.xml.
@@ -644,7 +631,6 @@ extension DownloadManager {
     /// Get formatted total download size string
     func getFormattedTotalDownloadedSize() async -> String {
         let totalSize = if Self.directory.exists {
-            // includes staging directories, so this total matches the per-series sizes beside it
             await calculateDirectorySize(Self.directory, includingHidden: true)
         } else {
             Int64(0)

--- a/Shared/Data/Downloads/DownloadManager.swift
+++ b/Shared/Data/Downloads/DownloadManager.swift
@@ -141,8 +141,11 @@ actor DownloadManager {
         if chapterDirectory.exists || chapterDirectory.appendingPathExtension("cbz").exists {
             return .finished
         } else {
-            if cache.tmpDirectory(for: chapter).exists {
-                return .queued
+            let tmpDirectory = cache.tmpDirectory(for: chapter)
+            if tmpDirectory.exists {
+                // A staging directory is either a download in progress or one that finished with
+                // pages missing, and only the marker tells them apart.
+                return cache.hasFailureMarker(inTmpDirectory: tmpDirectory) ? .failed : .queued
             } else {
                 return .none
             }
@@ -227,17 +230,26 @@ extension DownloadManager {
         for chapter in chapters {
             let directory = cache.directory(for: chapter)
             let archiveURL = directory.appendingPathExtension("cbz")
-            if directory.exists || archiveURL.exists {
+            // a download that finished with pages missing leaves a marked staging directory instead
+            // of a chapter, and removing it is the only way back out of the failed state
+            let tmpDirectory = cache.tmpDirectory(for: chapter)
+            let failedDirectory = cache.hasFailureMarker(inTmpDirectory: tmpDirectory) ? tmpDirectory : nil
+            if directory.exists || archiveURL.exists || failedDirectory != nil {
                 directory.removeItem()
                 archiveURL.removeItem()
+                failedDirectory?.removeItem()
                 await cache.remove(chapter: chapter)
 
                 // check if all chapters have been removed (then remove manga directory)
                 let manga = chapter.mangaIdentifier
+                // a failed download counts as remaining, otherwise removing one of them takes the
+                // whole manga directory with it and the rest go silently
                 let hasRemainingChapters = cache.directory(for: manga)
-                    .contents
+                    .contentsIncludingHidden
                     .contains {
-                        ($0.isDirectory || $0.pathExtension == "cbz") && !$0.lastPathComponent.hasPrefix(".tmp")
+                        guard $0.isDirectory || $0.pathExtension == "cbz" else { return false }
+                        guard $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) else { return true }
+                        return cache.hasFailureMarker(inTmpDirectory: $0)
                     }
                 if !hasRemainingChapters {
                     await deleteChapters(for: manga)
@@ -353,14 +365,20 @@ extension DownloadManager {
             for mangaDirectory in mangaDirectories {
                 let mangaId = mangaDirectory.lastPathComponent
 
-                // Count chapters and calculate total size
-                let chapterDirectories = mangaDirectory.contents.filter {
-                    ($0.isDirectory || $0.pathExtension == "cbz") && !$0.lastPathComponent.hasPrefix(".tmp")
+                // Count chapters and calculate total size. A download that stopped with pages
+                // missing counts too, so that a manga holding only those still appears here and
+                // can be removed.
+                let chapterDirectories = mangaDirectory.contentsIncludingHidden.filter {
+                    guard $0.isDirectory || $0.pathExtension == "cbz" else { return false }
+                    guard $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) else { return true }
+                    return cache.hasFailureMarker(inTmpDirectory: $0)
                 }
 
                 guard !chapterDirectories.isEmpty else { continue }
 
-                let totalSize = await calculateDirectorySize(mangaDirectory)
+                // hidden entries are counted so that a failed download, which is listed above,
+                // contributes the space it occupies rather than going unaccounted for
+                let totalSize = await calculateDirectorySize(mangaDirectory, includingHidden: true)
                 let chapterCount = chapterDirectories.count
 
                 // Try to load metadata from the manga directory first
@@ -465,13 +483,23 @@ extension DownloadManager {
         guard mangaDirectory.exists else { return [] }
 
         let chapterDirectories = mangaDirectory.contents.filter {
-            ($0.isDirectory || $0.pathExtension == "cbz") && !$0.lastPathComponent.hasPrefix(".tmp")
+            ($0.isDirectory || $0.pathExtension == "cbz") && !$0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix)
+        }
+        // a download that stopped with pages missing never leaves its staging directory, and is
+        // listed here as well: otherwise it takes up space that nothing on screen accounts for
+        let failedDirectories = mangaDirectory.contentsIncludingHidden.filter {
+            $0.isDirectory && cache.hasFailureMarker(inTmpDirectory: $0)
         }
 
         var chapters: [DownloadedChapterInfo] = []
 
-        for chapterDirectory in chapterDirectories {
-            let chapterId = chapterDirectory.deletingPathExtension().lastPathComponent
+        for chapterDirectory in chapterDirectories + failedDirectories {
+            let failed = failedDirectories.contains(chapterDirectory)
+            let chapterId = if failed {
+                String(chapterDirectory.lastPathComponent.dropFirst(DownloadCache.tmpDirectoryPrefix.count))
+            } else {
+                chapterDirectory.deletingPathExtension().lastPathComponent
+            }
             let size = await calculateDirectorySize(chapterDirectory)
 
             // Get directory creation date as download date
@@ -488,6 +516,7 @@ extension DownloadManager {
                 volumeNumber: metadata?.volume.flatMap { Float($0) },
                 size: size,
                 downloadDate: downloadDate,
+                failed: failed,
                 chapter: metadata?.toChapter()
             )
 
@@ -575,7 +604,7 @@ extension DownloadManager {
     }
 
     /// Calculate the total size of a directory in bytes.
-    private func calculateDirectorySize(_ directory: URL) async -> Int64 {
+    private func calculateDirectorySize(_ directory: URL, includingHidden: Bool = false) async -> Int64 {
         guard directory.exists else { return 0 }
 
         return await withCheckedContinuation { continuation in
@@ -586,7 +615,7 @@ extension DownloadManager {
                     if let enumerator = FileManager.default.enumerator(
                         at: directory,
                         includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
-                        options: [.skipsHiddenFiles]
+                        options: includingHidden ? [] : [.skipsHiddenFiles]
                     ) {
                         for case let fileURL as URL in enumerator {
                             do {
@@ -615,7 +644,8 @@ extension DownloadManager {
     /// Get formatted total download size string
     func getFormattedTotalDownloadedSize() async -> String {
         let totalSize = if Self.directory.exists {
-            await calculateDirectorySize(Self.directory)
+            // includes staging directories, so this total matches the per-series sizes beside it
+            await calculateDirectorySize(Self.directory, includingHidden: true)
         } else {
             Int64(0)
         }

--- a/Shared/Data/Downloads/DownloadQueue.swift
+++ b/Shared/Data/Downloads/DownloadQueue.swift
@@ -129,6 +129,10 @@ actor DownloadQueue {
             guard !(await cache.isChapterDownloaded(identifier: identifier)) else {
                 continue
             }
+            // a chapter queued again after failing is no longer failed, and the marker has to go
+            // now rather than when the download reaches the front of the queue, or it reports
+            // itself failed for as long as it waits
+            cache.discardFailedDownload(for: identifier)
             // create tmp directory so we know it's queued
             cache.tmpDirectory(for: identifier).createDirectory()
             let download = Download.from(manga: manga, chapter: chapter)
@@ -184,8 +188,11 @@ actor DownloadQueue {
             await task.cancel(manga: manga)
         } else {
             cache.directory(for: manga)
-                .contents
-                .filter { $0.lastPathComponent.hasPrefix(".tmp") }
+                .contentsIncludingHidden
+                .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
+                // a marked directory is a download that already failed rather than one in flight,
+                // so cancelling the manga's downloads must leave it alone
+                .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
                 .forEach { $0.removeItem() }
         }
         saveQueueState()
@@ -305,6 +312,19 @@ extension DownloadQueue: DownloadTaskDelegate {
         progressBlocks.removeValue(forKey: download.chapterIdentifier)
         onCompletion?()
         NotificationCenter.default.post(name: .downloadFinished, object: download)
+    }
+
+    /// A download that finished with pages missing, which leaves something on disk rather than
+    /// nothing: see `DownloadTask.handleChapterDownloadFinish`.
+    ///
+    /// It leaves the queue the same way a finished one does, since there is nothing left to run.
+    /// What differs is the notification, so a listener can tell a chapter that arrived from one
+    /// that arrived incomplete.
+    func downloadFailed(download: Download) async {
+        await downloadCancelled(download: download)
+        progressBlocks.removeValue(forKey: download.chapterIdentifier)
+        onCompletion?()
+        NotificationCenter.default.post(name: .downloadFailed, object: download)
     }
 
     func downloadCancelled(download: Download) async {

--- a/Shared/Data/Downloads/DownloadQueue.swift
+++ b/Shared/Data/Downloads/DownloadQueue.swift
@@ -129,12 +129,12 @@ actor DownloadQueue {
             guard !(await cache.isChapterDownloaded(identifier: identifier)) else {
                 continue
             }
-            // a chapter queued again after failing is no longer failed, and the marker has to go
-            // now rather than when the download reaches the front of the queue, or it reports
-            // itself failed for as long as it waits
-            cache.discardFailedDownload(for: identifier)
+
             // create tmp directory so we know it's queued
-            cache.tmpDirectory(for: identifier).createDirectory()
+            let tmpDirectory = cache.tmpDirectory(for: identifier)
+            tmpDirectory.removeItem() // remove in case it exists from a previous failed download
+            tmpDirectory.createDirectory()
+
             let download = Download.from(manga: manga, chapter: chapter)
             downloads.append(download)
             if queue[manga.sourceKey] == nil {
@@ -189,10 +189,10 @@ actor DownloadQueue {
         } else {
             cache.directory(for: manga)
                 .contentsIncludingHidden
-                .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
-                // a marked directory is a download that already failed rather than one in flight,
-                // so cancelling the manga's downloads must leave it alone
-                .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
+                .filter {
+                    $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix)
+                        && !cache.hasFailureMarker(inTmpDirectory: $0)
+                }
                 .forEach { $0.removeItem() }
         }
         saveQueueState()
@@ -314,12 +314,6 @@ extension DownloadQueue: DownloadTaskDelegate {
         NotificationCenter.default.post(name: .downloadFinished, object: download)
     }
 
-    /// A download that finished with pages missing, which leaves something on disk rather than
-    /// nothing: see `DownloadTask.handleChapterDownloadFinish`.
-    ///
-    /// It leaves the queue the same way a finished one does, since there is nothing left to run.
-    /// What differs is the notification, so a listener can tell a chapter that arrived from one
-    /// that arrived incomplete.
     func downloadFailed(download: Download) async {
         await downloadCancelled(download: download)
         progressBlocks.removeValue(forKey: download.chapterIdentifier)

--- a/Shared/Data/Downloads/DownloadTask.swift
+++ b/Shared/Data/Downloads/DownloadTask.swift
@@ -17,6 +17,7 @@ protocol DownloadTaskDelegate: AnyObject, Sendable {
     func taskFinished(task: DownloadTask) async
     func downloadProgressChanged(download: Download) async
     func downloadFinished(download: Download) async
+    func downloadFailed(download: Download) async
     func downloadCancelled(download: Download) async
 }
 
@@ -30,6 +31,8 @@ actor DownloadTask: Identifiable {
 
     private var currentPage: Int = 0
     private var failedPages: Int = 0
+    /// Which pages failed, in the order they were reported, for the marker a partial failure leaves.
+    private var failedPageNumbers: [Int] = []
     private var pages: [Page] = []
 
     private(set) var running: Bool = false
@@ -83,6 +86,7 @@ actor DownloadTask: Identifiable {
                 pages = []
                 currentPage = 0
                 failedPages = 0
+                failedPageNumbers = []
             }
             // remove chapter tmp download directory
             let download = downloads[index]
@@ -104,6 +108,7 @@ actor DownloadTask: Identifiable {
                         pages = []
                         currentPage = 0
                         failedPages = 0
+                        failedPageNumbers = []
                     }
                     downloads[i].status = .cancelled
                     await delegate?.downloadCancelled(download: downloads[i])
@@ -111,8 +116,9 @@ actor DownloadTask: Identifiable {
                 }
                 downloads.remove(atOffsets: cancelled)
                 cache.directory(for: manga)
-                    .contents
-                    .filter { $0.lastPathComponent.hasPrefix(".tmp") }
+                    .contentsIncludingHidden
+                    .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
+                    .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
                     .forEach { $0.removeItem() }
                 if wasRunning {
                     resume()
@@ -131,13 +137,15 @@ actor DownloadTask: Identifiable {
             Task {
                 for manga in manga {
                     cache.directory(for: manga)
-                        .contents
-                        .filter { $0.lastPathComponent.hasPrefix(".tmp") }
+                        .contentsIncludingHidden
+                        .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
+                        .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
                         .forEach { $0.removeItem() }
                 }
                 pages = []
                 currentPage = 0
                 failedPages = 0
+                failedPageNumbers = []
                 await delegate?.taskCancelled(task: self)
             }
         }
@@ -194,6 +202,18 @@ extension DownloadTask {
         let url: URL
         let context: PageContext?
         let targetPath: URL
+        /// The page's position in the chapter, one-based, which is the number it is stored under.
+        let pageNumber: Int
+    }
+
+    /// A finished page download, carrying the page it belongs to.
+    ///
+    /// A concurrent download hands results back in whatever order they finish, so a failure has to
+    /// name its page rather than be inferred from how many have completed.
+    struct PageDownloadResult {
+        let page: NetworkPage
+        let data: Data?
+        let targetPath: URL?
     }
 
     // perform download
@@ -202,6 +222,11 @@ extension DownloadTask {
 
         let download = downloads[0]
         downloads[0].status = .downloading
+
+        // an earlier attempt may have left this directory marked as failed, and this run supersedes
+        // it: the pages it holds are refetched here, and keeping the marker would both report the
+        // chapter as failed while it downloads and carry the marker into the promoted chapter
+        cache.discardFailedDownload(for: download.chapterIdentifier)
 
         let tmpDirectory = cache.tmpDirectory(for: download.chapterIdentifier)
         tmpDirectory.createDirectory()
@@ -233,7 +258,8 @@ extension DownloadTask {
                 networkPages.append(.init(
                     url: url,
                     context: page.context,
-                    targetPath: targetPath
+                    targetPath: targetPath,
+                    pageNumber: i + 1
                 ))
             } else {
                 currentPage += 1
@@ -248,6 +274,7 @@ extension DownloadTask {
                     }
                 } catch {
                     failedPages += 1
+                    failedPageNumbers.append(i + 1)
                     LogManager.logger.error("Error writing page data: \(error)")
                 }
             }
@@ -272,7 +299,7 @@ extension DownloadTask {
 
         if UserDefaults.standard.bool(forKey: "Downloads.parallel") {
             // download pages from the network concurrently
-            await withTaskGroup(of: (Data?, URL?).self) { taskGroup in
+            await withTaskGroup(of: PageDownloadResult.self) { taskGroup in
                 let groupSize = max(1, min(source.config?.maximumParallelRequests ?? Self.maxConcurrentPageTasks, Self.maxConcurrentPageTasks))
                 for pageGroup in networkPages.chunked(into: groupSize) {
                     for page in pageGroup {
@@ -280,38 +307,49 @@ extension DownloadTask {
                             await self.downloadPage(page, source: source, pageInterceptor: pageInterceptor, tmpDirectory: tmpDirectory)
                         }
                     }
-                    for await (data, path) in taskGroup {
+                    for await result in taskGroup {
                         guard tmpDirectory.exists else {
                             // download was cancelled, stop processing
                             return
                         }
-                        if let data, let path {
+                        if let data = result.data, let path = result.targetPath {
                             do {
                                 try data.write(to: path)
                             } catch {
                                 LogManager.logger.error("Error writing downloaded image: \(error)")
                             }
                         }
-                        await self.incrementProgress(for: download.chapterIdentifier, failed: data == nil)
+                        await self.incrementProgress(
+                            for: download.chapterIdentifier,
+                            failedPage: result.data == nil ? result.page.pageNumber : nil
+                        )
                     }
                 }
             }
         } else {
             // download pages from the network serially
             for page in networkPages {
-                let (data, path) = await self.downloadPage(page, source: source, pageInterceptor: pageInterceptor, tmpDirectory: tmpDirectory)
+                let result = await self.downloadPage(
+                    page,
+                    source: source,
+                    pageInterceptor: pageInterceptor,
+                    tmpDirectory: tmpDirectory
+                )
                 guard tmpDirectory.exists else {
                     // download was cancelled, stop processing
                     return
                 }
-                if let data, let path {
+                if let data = result.data, let path = result.targetPath {
                     do {
                         try data.write(to: path)
                     } catch {
                         LogManager.logger.error("Error writing downloaded image: \(error)")
                     }
                 }
-                await self.incrementProgress(for: download.chapterIdentifier, failed: data == nil)
+                await self.incrementProgress(
+                    for: download.chapterIdentifier,
+                    failedPage: result.data == nil ? page.pageNumber : nil
+                )
             }
         }
 
@@ -327,7 +365,7 @@ extension DownloadTask {
         source: AidokuRunner.Source,
         pageInterceptor: PageInterceptorProcessor?,
         tmpDirectory: URL
-    ) async -> (Data?, URL?) {
+    ) async -> PageDownloadResult {
         let urlRequest = await source.getModifiedImageRequest(
             url: page.url,
             context: page.context
@@ -379,7 +417,7 @@ extension DownloadTask {
             resultPath = page.targetPath.appendingPathExtension(fileExtention)
         }
 
-        return (resultData, resultPath)
+        return .init(page: page, data: resultData, targetPath: resultPath)
     }
 
     // fetch page data, retrying on any non-2xx HTTP response or network error
@@ -429,7 +467,7 @@ extension DownloadTask {
         }
     }
 
-    private func incrementProgress(for id: ChapterIdentifier, failed: Bool = false) async {
+    private func incrementProgress(for id: ChapterIdentifier, failedPage: Int? = nil) async {
         guard let downloadIndex = downloads.firstIndex(where: { $0.chapterIdentifier == id }) else {
             return
         }
@@ -439,8 +477,9 @@ extension DownloadTask {
         Task {
             await delegate?.downloadProgressChanged(download: download)
         }
-        if failed {
+        if let failedPage {
             failedPages += 1
+            failedPageNumbers.append(failedPage)
         }
         if currentPage == pages.count {
             await handleChapterDownloadFinish(download: download)
@@ -459,10 +498,23 @@ extension DownloadTask {
                 await delegate?.downloadCancelled(download: download)
             }
             LogManager.logger.error("Chapter failed to download: \(download.chapter.formattedTitle())")
-        } else {
-            if failedPages > 0 {
-                LogManager.logger.error("Chapter downloaded with \(failedPages) failed pages: \(download.chapter.formattedTitle())")
+        } else if failedPages > 0 {
+            // Some pages are missing, so the chapter is not the chapter. Promoting it here is what
+            // issue #243 is: the result was indistinguishable from a complete download, and a
+            // reader met the gap only on reaching it. The staging directory stays where it is,
+            // marked, so that it reports itself failed rather than queued.
+            LogManager.logger.error("Chapter downloaded with \(failedPages) failed pages: \(download.chapter.formattedTitle())")
+            // the downloads settings page lists this directory, so it needs the metadata a promoted
+            // chapter carries, otherwise there is nothing to name it by but its key
+            await DownloadManager.shared.saveChapterMetadata(manga: download.manga, chapter: download.chapter, to: tmpDirectory)
+            markFailed(tmpDirectory: tmpDirectory)
+            if let downloadIndex = downloads.firstIndex(where: { $0 == download }) {
+                downloads[downloadIndex].status = .failed
+                let failed = downloads[downloadIndex]
+                downloads.remove(at: downloadIndex)
+                await delegate?.downloadFailed(download: failed)
             }
+        } else {
             do {
                 // Save chapter metadata after successful download
                 await DownloadManager.shared.saveChapterMetadata(manga: download.manga, chapter: download.chapter, to: tmpDirectory)
@@ -504,7 +556,23 @@ extension DownloadTask {
         pages = []
         currentPage = 0
         failedPages = 0
+        failedPageNumbers = []
         await next()
+    }
+
+    /// Writes the marker that tells a failed download from one still running.
+    ///
+    /// The pages it names are the ones to refetch, one-based as they are stored, which is what a
+    /// resume would ask for. A marker
+    /// that cannot be written leaves the directory looking like a download in progress, which is
+    /// the behaviour that already existed, so it is logged rather than escalated.
+    private func markFailed(tmpDirectory: URL) {
+        let marker = cache.failureMarker(inTmpDirectory: tmpDirectory)
+        do {
+            try JSONEncoder().encode(failedPageNumbers.sorted()).write(to: marker)
+        } catch {
+            LogManager.logger.error("Error marking failed download (\(tmpDirectory)): \(error)")
+        }
     }
 }
 

--- a/Shared/Data/Downloads/DownloadTask.swift
+++ b/Shared/Data/Downloads/DownloadTask.swift
@@ -31,7 +31,6 @@ actor DownloadTask: Identifiable {
 
     private var currentPage: Int = 0
     private var failedPages: Int = 0
-    /// Which pages failed, in the order they were reported, for the marker a partial failure leaves.
     private var failedPageNumbers: [Int] = []
     private var pages: [Page] = []
 
@@ -117,8 +116,10 @@ actor DownloadTask: Identifiable {
                 downloads.remove(atOffsets: cancelled)
                 cache.directory(for: manga)
                     .contentsIncludingHidden
-                    .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
-                    .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
+                    .filter {
+                        $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix)
+                            && !cache.hasFailureMarker(inTmpDirectory: $0)
+                    }
                     .forEach { $0.removeItem() }
                 if wasRunning {
                     resume()
@@ -138,8 +139,10 @@ actor DownloadTask: Identifiable {
                 for manga in manga {
                     cache.directory(for: manga)
                         .contentsIncludingHidden
-                        .filter { $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix) }
-                        .filter { !cache.hasFailureMarker(inTmpDirectory: $0) }
+                        .filter {
+                            $0.lastPathComponent.hasPrefix(DownloadCache.tmpDirectoryPrefix)
+                                && !cache.hasFailureMarker(inTmpDirectory: $0)
+                        }
                         .forEach { $0.removeItem() }
                 }
                 pages = []
@@ -223,12 +226,8 @@ extension DownloadTask {
         let download = downloads[0]
         downloads[0].status = .downloading
 
-        // an earlier attempt may have left this directory marked as failed, and this run supersedes
-        // it: the pages it holds are refetched here, and keeping the marker would both report the
-        // chapter as failed while it downloads and carry the marker into the promoted chapter
-        cache.discardFailedDownload(for: download.chapterIdentifier)
-
         let tmpDirectory = cache.tmpDirectory(for: download.chapterIdentifier)
+        tmpDirectory.removeItem() // remove in case it exists from a previous failed download
         tmpDirectory.createDirectory()
 
         if pages.isEmpty {
@@ -488,19 +487,18 @@ extension DownloadTask {
             }
             LogManager.logger.error("Chapter failed to download: \(download.chapter.formattedTitle())")
         } else if failedPages > 0 {
-            // Some pages are missing, so the chapter is not the chapter. Promoting it here is what
-            // issue #243 is: the result was indistinguishable from a complete download, and a
-            // reader met the gap only on reaching it. The staging directory stays where it is,
-            // marked, so that it reports itself failed rather than queued.
-            LogManager.logger.error("Chapter downloaded with \(failedPages) failed pages: \(download.chapter.formattedTitle())")
-            // the downloads settings page lists this directory, so it needs the metadata a promoted
-            // chapter carries, otherwise there is nothing to name it by but its key
+            LogManager.logger.error(
+                "Chapter downloaded with \(failedPages) failed page\(failedPages == 1 ? "" : "s"): \(download.chapter.formattedTitle())"
+            )
+
+            // save metadata for failed download in downloads view
             await DownloadManager.shared.saveChapterMetadata(manga: download.manga, chapter: download.chapter, to: tmpDirectory)
+
             markFailed(tmpDirectory: tmpDirectory)
+
             if let downloadIndex = downloads.firstIndex(where: { $0 == download }) {
                 downloads[downloadIndex].status = .failed
-                let failed = downloads[downloadIndex]
-                downloads.remove(at: downloadIndex)
+                let failed = downloads.remove(at: downloadIndex)
                 await delegate?.downloadFailed(download: failed)
             }
         } else {
@@ -549,12 +547,7 @@ extension DownloadTask {
         await next()
     }
 
-    /// Writes the marker that tells a failed download from one still running.
-    ///
-    /// The pages it names are the ones to refetch, one-based as they are stored, which is what a
-    /// resume would ask for. A marker
-    /// that cannot be written leaves the directory looking like a download in progress, which is
-    /// the behaviour that already existed, so it is logged rather than escalated.
+    // store file with failed pages in failed download directory
     private func markFailed(tmpDirectory: URL) {
         let marker = cache.failureMarker(inTmpDirectory: tmpDirectory)
         do {

--- a/Shared/Data/Downloads/Models/DownloadedMangaInfo.swift
+++ b/Shared/Data/Downloads/Models/DownloadedMangaInfo.swift
@@ -74,6 +74,8 @@ struct DownloadedChapterInfo: Identifiable, Hashable {
     let volumeNumber: Float?     // For formatted titles
     let size: Int64
     let downloadDate: Date?
+    /// Whether this is a download that stopped with pages missing rather than a complete chapter.
+    let failed: Bool
 
     let chapter: AidokuRunner.Chapter?
 
@@ -141,6 +143,7 @@ struct DownloadedChapterInfo: Identifiable, Hashable {
         volumeNumber: Float? = nil,
         size: Int64,
         downloadDate: Date? = nil,
+        failed: Bool = false,
         chapter: AidokuRunner.Chapter? = nil
     ) {
         self.id = chapterId
@@ -150,6 +153,7 @@ struct DownloadedChapterInfo: Identifiable, Hashable {
         self.volumeNumber = volumeNumber
         self.size = size
         self.downloadDate = downloadDate
+        self.failed = failed
         self.chapter = chapter
     }
 

--- a/Shared/Extensions/FileManager.swift
+++ b/Shared/Extensions/FileManager.swift
@@ -24,6 +24,14 @@ extension URL {
         (try? FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)) ?? []
     }
 
+    /// Directory contents with hidden entries included.
+    ///
+    /// A download stages itself into a directory whose name begins with a dot, so `contents` never
+    /// reports one and every filter written against that prefix has nothing to match.
+    var contentsIncludingHidden: [URL] {
+        (try? FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil)) ?? []
+    }
+
     var isDirectory: Bool {
         (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }

--- a/Shared/Extensions/FileManager.swift
+++ b/Shared/Extensions/FileManager.swift
@@ -25,9 +25,6 @@ extension URL {
     }
 
     /// Directory contents with hidden entries included.
-    ///
-    /// A download stages itself into a directory whose name begins with a dot, so `contents` never
-    /// reports one and every filter written against that prefix has nothing to match.
     var contentsIncludingHidden: [URL] {
         (try? FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil)) ?? []
     }

--- a/Shared/Extensions/NotificationName.swift
+++ b/Shared/Extensions/NotificationName.swift
@@ -51,6 +51,7 @@ extension Notification.Name {
     // downloads
     static let downloadProgressed = Self("downloadProgressed")
     static let downloadFinished = Self("downloadFinished")
+    static let downloadFailed = Self("downloadFailed")
     static let downloadRemoved = Self("downloadRemoved")
     static let downloadCancelled = Self("downloadCancelled")
     static let downloadsRemoved = Self("downloadsRemoved")

--- a/Shared/Localization/en.lproj/Localizable.strings
+++ b/Shared/Localization/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "NO_DOWNLOADS" = "No Downloads";
 "NO_DOWNLOADS_TEXT" = "Downloaded content will appear here.";
 "DOWNLOADED_CHAPTERS" = "Downloaded Chapters";
+"DOWNLOAD_INCOMPLETE" = "Incomplete Download";
 "TOTAL_DOWNLOADS" = "Total Downloads";
 "%i_SERIES" = "%i series";
 "IN_LIBRARY" = "In Library";

--- a/iOS/New/Views/Manga/ChapterTableCell.swift
+++ b/iOS/New/Views/Manga/ChapterTableCell.swift
@@ -22,6 +22,11 @@ struct ChapterTableCell: View {
         downloadStatus == .finished
     }
 
+    /// A download that stopped with pages missing, which is neither downloaded nor in progress.
+    var downloadFailed: Bool {
+        downloadStatus == .failed
+    }
+
     var locked: Bool {
         chapter.locked && !downloaded
     }
@@ -59,6 +64,10 @@ struct ChapterTableCell: View {
                 Image(systemName: "arrow.down.circle.fill")
                     .imageScale(.small)
                     .foregroundStyle(.tertiary)
+            } else if downloadFailed {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .imageScale(.small)
+                    .foregroundStyle(.orange)
             } else if let progress {
                 DownloadProgressView(progress: progress)
                     .frame(width: 13, height: 13)

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -559,8 +559,6 @@ extension MangaView.ViewModel {
     }
 
     private func loadDownloadStatus() async {
-        // the second list is on disk by definition, but a download that stopped with pages missing
-        // is on disk as well without being a chapter, so its status is asked for rather than assumed
         for chapter in chapters + otherDownloadedChapters {
             downloadStatus[chapter.key] = DownloadManager.shared.getDownloadStatus(
                 for: .init(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)

--- a/iOS/New/Views/Manga/MangaView+ViewModel.swift
+++ b/iOS/New/Views/Manga/MangaView+ViewModel.swift
@@ -248,6 +248,7 @@ extension MangaView {
 
             for name in [
                 Notification.Name.downloadFinished,
+                Notification.Name.downloadFailed,
                 Notification.Name.downloadRemoved,
                 Notification.Name.downloadCancelled
             ] {
@@ -558,13 +559,12 @@ extension MangaView.ViewModel {
     }
 
     private func loadDownloadStatus() async {
-        for chapter in chapters {
+        // the second list is on disk by definition, but a download that stopped with pages missing
+        // is on disk as well without being a chapter, so its status is asked for rather than assumed
+        for chapter in chapters + otherDownloadedChapters {
             downloadStatus[chapter.key] = DownloadManager.shared.getDownloadStatus(
                 for: .init(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
             )
-        }
-        for chapter in otherDownloadedChapters {
-            downloadStatus[chapter.key] = .finished
         }
     }
 

--- a/iOS/New/Views/Manga/MangaView.swift
+++ b/iOS/New/Views/Manga/MangaView.swift
@@ -506,7 +506,9 @@ extension MangaView {
                     Label(NSLocalizedString("REMOVE"), systemImage: "trash")
                 }
             } else {
-                if downloadStatus == .finished {
+                // a failed download leaves a partial chapter on disk, so it is removable in the same
+                // way a complete one is; it keeps the download button as well, which retries it
+                if downloadStatus == .finished || downloadStatus == .failed {
                     Button(role: .destructive) {
                         Task {
                             await DownloadManager.shared.delete(chapters: [identifier])
@@ -874,7 +876,9 @@ private struct RightNavbarButton: View, Equatable {
         self.bookmarked = viewModel.bookmarked
         self.hasCategories = !CoreDataManager.shared.getCategoryTitles(sorted: false).isEmpty
         self.url = viewModel.manga.url
-        self.hasDownloads = viewModel.downloadStatus.contains(where: { $0.value == .finished })
+        // a failed download occupies space like a finished one does, so removing everything has to
+        // be offered for it too
+        self.hasDownloads = viewModel.downloadStatus.contains(where: { $0.value == .finished || $0.value == .failed })
         self.refresh = refreshController.refresh
 
         self.markAllRead = markAllRead

--- a/iOS/New/Views/Manga/MangaView.swift
+++ b/iOS/New/Views/Manga/MangaView.swift
@@ -876,8 +876,6 @@ private struct RightNavbarButton: View, Equatable {
         self.bookmarked = viewModel.bookmarked
         self.hasCategories = !CoreDataManager.shared.getCategoryTitles(sorted: false).isEmpty
         self.url = viewModel.manga.url
-        // a failed download occupies space like a finished one does, so removing everything has to
-        // be offered for it too
         self.hasDownloads = viewModel.downloadStatus.contains(where: { $0.value == .finished || $0.value == .failed })
         self.refresh = refreshController.refresh
 

--- a/iOS/New/Views/Settings/Downloads/DownloadedMangaView+ViewModel.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadedMangaView+ViewModel.swift
@@ -280,8 +280,6 @@ extension DownloadedMangaView.ViewModel {
                 else { return false }
                 return true
             }),
-            // a download that failed leaves a partial chapter in this list, so it has to refresh
-            // the same way a finished one does
             (.downloadFailed, { [weak self] notification in
                 guard let download = notification.object as? Download,
                       download.mangaIdentifier == self?.manga.mangaIdentifier

--- a/iOS/New/Views/Settings/Downloads/DownloadedMangaView+ViewModel.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadedMangaView+ViewModel.swift
@@ -280,6 +280,14 @@ extension DownloadedMangaView.ViewModel {
                 else { return false }
                 return true
             }),
+            // a download that failed leaves a partial chapter in this list, so it has to refresh
+            // the same way a finished one does
+            (.downloadFailed, { [weak self] notification in
+                guard let download = notification.object as? Download,
+                      download.mangaIdentifier == self?.manga.mangaIdentifier
+                else { return false }
+                return true
+            }),
             (.downloadsQueued, { [weak self] notification in
                 guard let downloads = notification.object as? [Download] else { return false }
                 return downloads.contains { $0.mangaIdentifier == self?.manga.mangaIdentifier }

--- a/iOS/New/Views/Settings/Downloads/DownloadedMangaView.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadedMangaView.swift
@@ -114,11 +114,17 @@ struct DownloadedMangaView: View {
                         ChapterRow(chapter: chapter, history: viewModel.readingHistory[chapter.chapterId])
                     }
                     .foregroundStyle(.primary)
+                    // a download that stopped with pages missing has no chapter to open or share:
+                    // opening it would fall through to the source and quietly read the chapter
+                    // online instead, which is not what tapping a downloaded chapter means
+                    .disabled(chapter.failed)
                     .contextMenu {
-                        Button {
-                            showShareSheet(chapter: chapter)
-                        } label: {
-                            Label(NSLocalizedString("SHARE"), systemImage: "square.and.arrow.up")
+                        if !chapter.failed {
+                            Button {
+                                showShareSheet(chapter: chapter)
+                            } label: {
+                                Label(NSLocalizedString("SHARE"), systemImage: "square.and.arrow.up")
+                            }
                         }
                     }
                     .matchedTransitionSourcePlease(id: chapter, in: transitionNamespace)
@@ -259,12 +265,23 @@ private struct ChapterRow: View {
             }
 
             Spacer()
+
+            if chapter.failed {
+                Image(systemName: "exclamationmark.circle.fill")
+                    .imageScale(.small)
+                    .foregroundStyle(.orange)
+            }
         }
         .contentShape(Rectangle())
     }
 
     private func formatChapterSubtitle() -> String? {
         var components: [String] = []
+
+        // a download that stopped with pages missing, which is why it is here without being readable
+        if chapter.failed {
+            components.append(NSLocalizedString("DOWNLOAD_INCOMPLETE"))
+        }
 
         // download date
         if let downloadDate = chapter.downloadDate {

--- a/iOS/New/Views/Settings/Downloads/DownloadedMangaView.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadedMangaView.swift
@@ -114,9 +114,6 @@ struct DownloadedMangaView: View {
                         ChapterRow(chapter: chapter, history: viewModel.readingHistory[chapter.chapterId])
                     }
                     .foregroundStyle(.primary)
-                    // a download that stopped with pages missing has no chapter to open or share:
-                    // opening it would fall through to the source and quietly read the chapter
-                    // online instead, which is not what tapping a downloaded chapter means
                     .disabled(chapter.failed)
                     .contextMenu {
                         if !chapter.failed {
@@ -278,7 +275,6 @@ private struct ChapterRow: View {
     private func formatChapterSubtitle() -> String? {
         var components: [String] = []
 
-        // a download that stopped with pages missing, which is why it is here without being readable
         if chapter.failed {
             components.append(NSLocalizedString("DOWNLOAD_INCOMPLETE"))
         }

--- a/iOS/New/Views/Settings/Downloads/DownloadsView+ViewModel.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadsView+ViewModel.swift
@@ -147,6 +147,9 @@ extension DownloadsView.ViewModel {
         // Low-priority updates that can be debounced
         let debouncedUpdateNotifications: [NSNotification.Name] = [
             .downloadFinished,
+            // a download that failed leaves a partial chapter listed here, so it changes this view
+            // exactly as a finished one does
+            .downloadFailed,
             .downloadsCancelled,
             .downloadsQueued,
             .downloadsPaused,

--- a/iOS/New/Views/Settings/Downloads/DownloadsView+ViewModel.swift
+++ b/iOS/New/Views/Settings/Downloads/DownloadsView+ViewModel.swift
@@ -147,8 +147,6 @@ extension DownloadsView.ViewModel {
         // Low-priority updates that can be debounced
         let debouncedUpdateNotifications: [NSNotification.Name] = [
             .downloadFinished,
-            // a download that failed leaves a partial chapter listed here, so it changes this view
-            // exactly as a finished one does
             .downloadFailed,
             .downloadsCancelled,
             .downloadsQueued,


### PR DESCRIPTION
Closes #243.

A chapter that finished downloading with pages missing was promoted exactly like a complete one, so it showed as downloaded and the gap was found only on reading it. This keeps such a download in a failed state instead, and represents that state in the manga details view and in the downloads settings page.

## Changes
- Make `handleChapterDownloadFinish` a three-way gate. It previously discarded a download only when every page failed; any other failure count took the branch that logs to `LogManager` and then promotes the staging directory. A download with some pages missing now keeps its staging directory, marks it, and reports `.failed` to the delegate.
- Mark a failed download with a `.failed` sentinel file inside its `.tmp_` directory, holding the numbers of the pages that failed. The marker sits inside the directory so that discarding the download remains a single `removeItem`, and is named so that it cannot be mistaken for a page.
- Return `.failed` from `getDownloadStatus` for a marked staging directory and `.queued` for an unmarked one. `DownloadStatus.failed` already existed in the enum and was never produced; a failed partial and a download in progress were identical on disk and both reported `.queued`.
- Add `DownloadTaskDelegate.downloadFailed` and a `.downloadFailed` notification, observed by the manga view model and by both downloads settings view models.
- Track which pages failed rather than how many. `NetworkPage` carries its one-based page number and `downloadPage` returns it with the result, since pages are fetched concurrently and complete out of order.
- Show a failed chapter in the manga details view with its own indicator. It stays locked, keeps its download button for retry, and offers removal.
- List a failed download in the downloads settings page with an "Incomplete Download" subtitle, and count its size, so the space it occupies can be seen and reclaimed. Its row is not tappable, because opening it would fall through to the source and read the chapter online. Chapter metadata is written into the staging directory on failure so that the page has a title to show.
- Discard whatever an earlier attempt left behind when a failed chapter is queued again. A retry refetches every page and the stored extension comes from the response, so keeping the earlier files risks a page arriving as a jpeg where it was a png before, leaving the promoted chapter holding that page twice.
- Remove a marked staging directory in `delete(chapters:)`, which is the only way back out of the failed state.

## Hidden staging directories
`URL.contents` passes `.skipsHiddenFiles`, and a staging directory is named `.tmp_<key>`. No listing has ever reported one, so every filter written against that prefix had nothing to match. A new `contentsIncludingHidden` is used where a failed download has to be visible. Two consequences beyond the new UI:

- `hasRemainingChapters` in `delete(chapters:)` counted only visible entries, so removing the last visible chapter of a manga concluded that the manga was empty, deleted the manga directory, and took any staging directory with it.
- The sweeps that clear staging directories when downloads are cancelled were dead for the same reason. They now run, with marked directories excluded so that cancelling a download does not delete a chapter that failed earlier. This is a behaviour change beyond the issue itself; I can move it to a separate PR if you prefer, though leaving dead code directly under a guard added here seemed worse.

## Out of scope
- Resume. A retry refetches every page. The marker already records which pages are missing and page files are named deterministically, so refetching only those is a small follow-up.
- A download interrupted by the app being killed leaves an unmarked staging directory, which still reports `.queued` indefinitely. This is pre-existing and untouched here.

## Testing
- Added `PartialDownloadTests` covering the status gate (none, queued for an unmarked staging directory, failed for a marked one, finished for a chapter directory), the marker's position inside the staging directory, and the discard behaviour on retry.
- Verified in the simulator against the Komga demo server. A chapter cut off mid-download ends failed, and the marker names exactly the pages missing from disk.
- Both recovery paths produce a correct archive, with contiguous pages and `ComicInfo.xml`, no marker inside the `.cbz`, and no duplicates from the reused staging directory. This covers retrying in place, and removing then downloading again.
- Several failed chapters selected together offer Download rather than Remove, and retrying clears all of them.
- Removing the last complete chapter of a manga leaves a failed partial intact, and Remove All Downloads stays reachable for a manga holding nothing else.
- Full `AidokuTests` suite passes on the iOS 26.5 simulator (365 tests), and there are no new SwiftLint warnings.
