### PR TITLE
feat: restore sources from backed-up source lists

### DIFF
--- a/Aidoku/App/AppDelegate.swift
+++ b/Aidoku/App/AppDelegate.swift
@@ -537,9 +537,8 @@ extension AppDelegate {
         topViewController?.present(loadingAlert, animated: true, completion: completion)
     }
 
-    /// Updates the message and progress of a shown loading indicator.
-    func updateLoadingIndicator(message: String, progress: Float) {
-        loadingAlert.message = message
+    /// Updates the  progress of a shown loading indicator.
+    func updateLoadingIndicator(progress: Float) {
         progressView.progress = progress
     }
 

--- a/Aidoku/App/AppDelegate.swift
+++ b/Aidoku/App/AppDelegate.swift
@@ -518,7 +518,12 @@ extension AppDelegate {
     }
 
     /// Shows a non-interactive loading indicator.
-    func showLoadingIndicator(style: LoadingStyle = .indefinite, completion: (() -> Void)? = nil) {
+    func showLoadingIndicator(
+        style: LoadingStyle = .indefinite,
+        message: String = NSLocalizedString("LOADING_ELLIPSIS"),
+        completion: (() -> Void)? = nil
+    ) {
+        loadingAlert.message = message
         switch style {
             case .indefinite:
                 loadingIndicator.startAnimating()
@@ -530,6 +535,12 @@ extension AppDelegate {
                 progressView.isHidden = false
         }
         topViewController?.present(loadingAlert, animated: true, completion: completion)
+    }
+
+    /// Updates the message and progress of a shown loading indicator.
+    func updateLoadingIndicator(message: String, progress: Float) {
+        loadingAlert.message = message
+        progressView.progress = progress
     }
 
     /// Dismisses a shown loading indicator.

--- a/Aidoku/App/Resources/Localization/en.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/en.lproj/Localizable.strings
@@ -661,10 +661,9 @@
 "MISSING_SOURCES" = "Missing Sources";
 "MISSING_SOURCES_TEXT" = "The restored backup may contain data from the following sources, which are not currently installed:";
 "RESTORE_MISSING_SOURCES" = "Restore Missing Sources?";
-"RESTORE_MISSING_SOURCES_TEXT_%@" = "Would you like to search the restored source lists and install any matches?\n\nSources to search for: %@";
+"RESTORE_MISSING_SOURCES_TEXT" = "Would you like to search for and install missing sources?";
 "INSTALL_SOURCES" = "Install Sources";
 "INSTALLING_SOURCES" = "Installing sources…";
-"INSTALLING_SOURCE_%@_%@_%@" = "Installing source %@ of %@:\n%@";
 "RESTORE_BACKUP" = "Restore to this backup?";
 "RESTORE_BACKUP_TEXT" = "All current data will be removed and replaced by the data from this backup.";
 "BACKUP_IMPORT_SUCCESS" = "Backup Imported";

--- a/Aidoku/App/Resources/Localization/en.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/en.lproj/Localizable.strings
@@ -660,6 +660,11 @@
 "BACKUP_INFO" = "Long press on a backup to export it, or swipe to the left to delete.";
 "MISSING_SOURCES" = "Missing Sources";
 "MISSING_SOURCES_TEXT" = "The restored backup may contain data from the following sources, which are not currently installed:";
+"RESTORE_MISSING_SOURCES" = "Restore Missing Sources?";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "Would you like to search the restored source lists and install any matches?\n\nSources to search for: %@";
+"INSTALL_SOURCES" = "Install Sources";
+"INSTALLING_SOURCES" = "Installing sources…";
+"INSTALLING_SOURCE_%@_%@_%@" = "Installing source %@ of %@:\n%@";
 "RESTORE_BACKUP" = "Restore to this backup?";
 "RESTORE_BACKUP_TEXT" = "All current data will be removed and replaced by the data from this backup.";
 "BACKUP_IMPORT_SUCCESS" = "Backup Imported";

--- a/Aidoku/App/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/fr.lproj/Localizable.strings
@@ -209,10 +209,9 @@
 "RENAME_BACKUP_TEXT" = "Entrez un nouveau nom pour votre sauvegarde";
 "MISSING_SOURCES" = "Sources manquantes";
 "RESTORE_MISSING_SOURCES" = "Restaurer les sources manquantes ?";
-"RESTORE_MISSING_SOURCES_TEXT_%@" = "Voulez-vous rechercher les sources dans les listes restaurées et installer celles qui sont trouvées ?\n\nSources à rechercher : %@";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "Voulez-vous rechercher les sources dans les listes restaurées et installer celles qui sont trouvées ?";
 "INSTALL_SOURCES" = "Installer les sources";
 "INSTALLING_SOURCES" = "Installation des sources…";
-"INSTALLING_SOURCE_%@_%@_%@" = "Installation de la source %@ sur %@ :\n%@";
 "RESET_SETTINGS" = "Réinitialiser les paramètres";
 "CORRUPTED_BACKUP" = "Sauvegarde endommagée";
 "BACKUP_INFO" = "Appuyez longuement sur une sauvegarde pour l'exporter, ou faites glisser vers la gauche pour la supprimer.";

--- a/Aidoku/App/Resources/Localization/fr.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/fr.lproj/Localizable.strings
@@ -208,6 +208,11 @@
 "BACKUP_NAME" = "Nom de la sauvegarde";
 "RENAME_BACKUP_TEXT" = "Entrez un nouveau nom pour votre sauvegarde";
 "MISSING_SOURCES" = "Sources manquantes";
+"RESTORE_MISSING_SOURCES" = "Restaurer les sources manquantes ?";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "Voulez-vous rechercher les sources dans les listes restaurées et installer celles qui sont trouvées ?\n\nSources à rechercher : %@";
+"INSTALL_SOURCES" = "Installer les sources";
+"INSTALLING_SOURCES" = "Installation des sources…";
+"INSTALLING_SOURCE_%@_%@_%@" = "Installation de la source %@ sur %@ :\n%@";
 "RESET_SETTINGS" = "Réinitialiser les paramètres";
 "CORRUPTED_BACKUP" = "Sauvegarde endommagée";
 "BACKUP_INFO" = "Appuyez longuement sur une sauvegarde pour l'exporter, ou faites glisser vers la gauche pour la supprimer.";

--- a/Aidoku/App/Resources/Localization/ja.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/ja.lproj/Localizable.strings
@@ -300,10 +300,9 @@
 "THAT_HAVENT_BEEN_READ" = "未読の漫画";
 "MISSING_SOURCES" = "ソースがありません";
 "RESTORE_MISSING_SOURCES" = "不足しているソースを復元しますか？";
-"RESTORE_MISSING_SOURCES_TEXT_%@" = "復元したソースリストを検索し、見つかったソースをインストールしますか？\n\n検索するソース：%@";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "復元したソースリストを検索し、見つかったソースをインストールしますか？";
 "INSTALL_SOURCES" = "ソースをインストール";
 "INSTALLING_SOURCES" = "ソースをインストール中…";
-"INSTALLING_SOURCE_%@_%@_%@" = "ソースをインストール中（%@/%@）：\n%@";
 "%@_AGO" = "%@前";
 "WEBTOON" = "Webtoon";
 "PILLARBOX_ORIENTATION" = "ピラーボックスの向き";

--- a/Aidoku/App/Resources/Localization/ja.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/ja.lproj/Localizable.strings
@@ -299,6 +299,11 @@
 "WITH_COMPLETED_STATUS" = "完結済みの漫画";
 "THAT_HAVENT_BEEN_READ" = "未読の漫画";
 "MISSING_SOURCES" = "ソースがありません";
+"RESTORE_MISSING_SOURCES" = "不足しているソースを復元しますか？";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "復元したソースリストを検索し、見つかったソースをインストールしますか？\n\n検索するソース：%@";
+"INSTALL_SOURCES" = "ソースをインストール";
+"INSTALLING_SOURCES" = "ソースをインストール中…";
+"INSTALLING_SOURCE_%@_%@_%@" = "ソースをインストール中（%@/%@）：\n%@";
 "%@_AGO" = "%@前";
 "WEBTOON" = "Webtoon";
 "PILLARBOX_ORIENTATION" = "ピラーボックスの向き";

--- a/Aidoku/App/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -189,6 +189,11 @@
 "CORRUPTED_BACKUP_TEXT" = "该备份有配置错误的数据。无法重新命名。";
 "BACKUP_INFO" = "长按备份以导出它，或向左滑动以删除。";
 "MISSING_SOURCES" = "图源缺失";
+"RESTORE_MISSING_SOURCES" = "恢复缺失图源？";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜索已恢复的图源列表并安装找到的图源？\n\n要搜索的图源：%@";
+"INSTALL_SOURCES" = "安装图源";
+"INSTALLING_SOURCES" = "正在安装图源…";
+"INSTALLING_SOURCE_%@_%@_%@" = "正在安装图源 %@/%@：\n%@";
 "MISSING_SOURCES_TEXT" = "恢复的备份可能包含来自以下图源的数据，但这些图源当前未安装：";
 "RESTORE_BACKUP" = "恢复到此备份？";
 "RESTORE_BACKUP_TEXT" = "所有当前数据将被删除并用此备份中的数据替换。";

--- a/Aidoku/App/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -190,10 +190,9 @@
 "BACKUP_INFO" = "长按备份以导出它，或向左滑动以删除。";
 "MISSING_SOURCES" = "图源缺失";
 "RESTORE_MISSING_SOURCES" = "恢复缺失图源？";
-"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜索已恢复的图源列表并安装找到的图源？\n\n要搜索的图源：%@";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜索已恢复的图源列表并安装找到的图源？";
 "INSTALL_SOURCES" = "安装图源";
 "INSTALLING_SOURCES" = "正在安装图源…";
-"INSTALLING_SOURCE_%@_%@_%@" = "正在安装图源 %@/%@：\n%@";
 "MISSING_SOURCES_TEXT" = "恢复的备份可能包含来自以下图源的数据，但这些图源当前未安装：";
 "RESTORE_BACKUP" = "恢复到此备份？";
 "RESTORE_BACKUP_TEXT" = "所有当前数据将被删除并用此备份中的数据替换。";

--- a/Aidoku/App/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "CORRUPTED_BACKUP_TEXT" = "此備份似乎有設定錯誤的資料。無法重新命名。";
 "BACKUP_INFO" = "長按備份項目以輸出，左滑以刪除。";
 "MISSING_SOURCES" = "缺少來源";
+"RESTORE_MISSING_SOURCES" = "恢復缺失來源？";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜尋已恢復的來源列表並安裝找到的來源？\n\n要搜尋的來源：%@";
+"INSTALL_SOURCES" = "安裝來源";
+"INSTALLING_SOURCES" = "正在安裝來源…";
+"INSTALLING_SOURCE_%@_%@_%@" = "正在安裝來源 %@/%@：\n%@";
 "RESTORE_BACKUP" = "用此備份回復？";
 "AUTH_FOR_LIBRARY" = "解鎖以查看書庫。";
 "LOCK_LIBRARY" = "鎖定書庫";

--- a/Aidoku/App/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Aidoku/App/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -210,10 +210,9 @@
 "BACKUP_INFO" = "長按備份項目以輸出，左滑以刪除。";
 "MISSING_SOURCES" = "缺少來源";
 "RESTORE_MISSING_SOURCES" = "恢復缺失來源？";
-"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜尋已恢復的來源列表並安裝找到的來源？\n\n要搜尋的來源：%@";
+"RESTORE_MISSING_SOURCES_TEXT_%@" = "是否要搜尋已恢復的來源列表並安裝找到的來源？";
 "INSTALL_SOURCES" = "安裝來源";
 "INSTALLING_SOURCES" = "正在安裝來源…";
-"INSTALLING_SOURCE_%@_%@_%@" = "正在安裝來源 %@/%@：\n%@";
 "RESTORE_BACKUP" = "用此備份回復？";
 "AUTH_FOR_LIBRARY" = "解鎖以查看書庫。";
 "LOCK_LIBRARY" = "鎖定書庫";

--- a/Aidoku/Core/Backup/BackupManager.swift
+++ b/Aidoku/Core/Backup/BackupManager.swift
@@ -289,39 +289,8 @@ extension BackupManager {
             UIApplication.shared.isIdleTimerDisabled = true
         }
 
-        Task {
-            // restore settings
-            if let settings = backup.settings {
-                // only restore source settings for sources installed, or built-in sources that will be added from the backup restore
-                let sources = await SourceManager.shared.getSourceInfos(sorted: false)
-                var sourceKeyPrefixes = sources.map { "\($0.sourceId)." }
-                for additionalSource in backup.sources ?? [] where additionalSource.config != nil {
-                    sourceKeyPrefixes.append("\(additionalSource.id).")
-                }
-                var needsMigrate = false
-                for (key, value) in settings {
-                    let hasAllowedPrefix = Self.allowedSettingsPrefixes.contains(where: { key.hasPrefix($0) })
-                        || sourceKeyPrefixes.contains(where: { key.hasPrefix($0) })
-                    guard
-                        hasAllowedPrefix,
-                        !Self.excludedSettings.contains(key),
-                        !Self.excludedSettingsPrefixes.contains(where: { key.hasPrefix($0) })
-                    else {
-                        continue
-                    }
-                    UserDefaults.standard.set(value.toRaw(), forKey: key)
-                    if AppDelegate.legacySettingKeys.contains(key) {
-                        needsMigrate = true
-                    }
-                }
-
-                if needsMigrate {
-                    await MainActor.run {
-                        UIApplication.shared.appDelegate?.migrateSettings()
-                    }
-                }
-            }
-
+        let sourceListsTask = Task {
+            await SourceManager.shared.waitForSourceListsLoad()
             // restore source lists
             guard let sourceLists = backup.sourceLists else { return }
             await SourceManager.shared.clearSourceLists()
@@ -559,6 +528,7 @@ extension BackupManager {
             }
         }
         let sourceTask = Task {
+            await sourceListsTask.value
             if let sourceItems = backup.sources {
                 let (result, needsRefresh) = await CoreDataManager.shared.container.performBackgroundTask { context in
                     var needsRefresh = false
@@ -597,6 +567,60 @@ extension BackupManager {
             backupError = error
         }
 
+        // Restore application and currently installed source settings as part of the initial restore.
+        await restoreSettings(from: backup)
+
+        await Task { @MainActor in
+            await UIApplication.shared.appDelegate?.hideLoadingIndicator()
+            UIApplication.shared.isIdleTimerDisabled = false
+        }.value
+
+        if backupError == nil {
+            let externalSourceKeys = Set((backup.sources ?? []).lazy.filter { $0.config == nil }.map(\.id))
+            let missingSourceKeys = await SourceManager.shared.missingExternalSourceKeys(in: externalSourceKeys)
+
+            if
+                !missingSourceKeys.isEmpty,
+                Reachability.getConnectionType() != .none,
+                await confirmExternalSourceRestore(keys: missingSourceKeys)
+            {
+                await MainActor.run {
+                    UIApplication.shared.isIdleTimerDisabled = true
+                    UIApplication.shared.appDelegate?.showLoadingIndicator(
+                        style: .progress,
+                        message: NSLocalizedString("INSTALLING_SOURCES")
+                    )
+                }
+
+                let installedSourceKeys = await SourceManager.shared.installExternalSources(
+                    keys: missingSourceKeys
+                ) { name, key, current, total in
+                    let sourceName = name.isEmpty || name == key ? key : "\(name) (\(key))"
+                    UIApplication.shared.appDelegate?.updateLoadingIndicator(
+                        message: String(
+                            format: NSLocalizedString("INSTALLING_SOURCE_%@_%@_%@"),
+                            String(current),
+                            String(total),
+                            sourceName
+                        ),
+                        progress: Float(current - 1) / Float(total)
+                    )
+                }
+
+                // Newly installed sources were not eligible during the initial settings restore.
+                await restoreSettings(from: backup, sourceKeys: installedSourceKeys)
+
+                await Task { @MainActor in
+                    UIApplication.shared.appDelegate?.updateLoadingIndicator(
+                        message: NSLocalizedString("INSTALLING_SOURCES"),
+                        progress: 1
+                    )
+                    await UIApplication.shared.appDelegate?.hideLoadingIndicator()
+                    UIApplication.shared.isIdleTimerDisabled = false
+                }.value
+            }
+        }
+
         NotificationCenter.default.post(name: .updateHistory, object: nil)
         NotificationCenter.default.post(name: .updateTrackers, object: nil)
         NotificationCenter.default.post(name: .updateCategories, object: nil)
@@ -604,10 +628,6 @@ extension BackupManager {
 
         await Task { @MainActor [backupError] in
             let delegate = UIApplication.shared.appDelegate
-            await delegate?.hideLoadingIndicator()
-
-            UIApplication.shared.isIdleTimerDisabled = false
-
             if let backupError {
                 // show error alert
                 delegate?.presentAlert(
@@ -632,6 +652,76 @@ extension BackupManager {
         }.value
 
         return backupError == nil
+    }
+
+    private func restoreSettings(from backup: Backup, sourceKeys: Set<String>? = nil) async {
+        guard let settings = backup.settings else { return }
+
+        let sourceKeyPrefixes: [String]
+        if let sourceKeys {
+            sourceKeyPrefixes = sourceKeys.map { "\($0)." }
+        } else {
+            // Only restore source settings for sources installed, or built-in sources added by the restore.
+            let sources = await SourceManager.shared.getSourceInfos(sorted: false)
+            sourceKeyPrefixes = sources.map { "\($0.sourceId)." } + (backup.sources ?? []).compactMap {
+                $0.config == nil ? nil : "\($0.id)."
+            }
+        }
+
+        var needsMigrate = false
+        for (key, value) in settings {
+            let hasAllowedPrefix = (sourceKeys == nil && Self.allowedSettingsPrefixes.contains { key.hasPrefix($0) })
+                || sourceKeyPrefixes.contains { key.hasPrefix($0) }
+            guard
+                hasAllowedPrefix,
+                !Self.excludedSettings.contains(key),
+                !Self.excludedSettingsPrefixes.contains(where: { key.hasPrefix($0) })
+            else {
+                continue
+            }
+            UserDefaults.standard.set(value.toRaw(), forKey: key)
+            if AppDelegate.legacySettingKeys.contains(key) {
+                needsMigrate = true
+            }
+        }
+
+        if needsMigrate {
+            await MainActor.run {
+                UIApplication.shared.appDelegate?.migrateSettings()
+            }
+        }
+    }
+
+    private func confirmExternalSourceRestore(keys: Set<String>) async -> Bool {
+        let message = String(
+            format: NSLocalizedString("RESTORE_MISSING_SOURCES_TEXT_%@"),
+            String(keys.count)
+        )
+            + keys.sorted().map { "\n- \($0)" }.joined()
+
+        return await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                guard
+                    let delegate = UIApplication.shared.appDelegate,
+                    delegate.topViewController != nil
+                else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                delegate.presentAlert(
+                    title: NSLocalizedString("RESTORE_MISSING_SOURCES"),
+                    message: message,
+                    actions: [
+                        UIAlertAction(title: NSLocalizedString("CANCEL"), style: .cancel) { _ in
+                            continuation.resume(returning: false)
+                        },
+                        UIAlertAction(title: NSLocalizedString("INSTALL_SOURCES"), style: .default) { _ in
+                            continuation.resume(returning: true)
+                        }
+                    ]
+                )
+            }
+        }
     }
 }
 

--- a/Aidoku/Core/Backup/BackupManager.swift
+++ b/Aidoku/Core/Backup/BackupManager.swift
@@ -592,30 +592,25 @@ extension BackupManager {
                     )
                 }
 
-                let installedSourceKeys = await SourceManager.shared.installExternalSources(
-                    keys: missingSourceKeys
-                ) { name, key, current, total in
-                    let sourceName = name.isEmpty || name == key ? key : "\(name) (\(key))"
-                    UIApplication.shared.appDelegate?.updateLoadingIndicator(
-                        message: String(
-                            format: NSLocalizedString("INSTALLING_SOURCE_%@_%@_%@"),
-                            String(current),
-                            String(total),
-                            sourceName
-                        ),
-                        progress: Float(current - 1) / Float(total)
-                    )
+                var installedSourceKeys: Set<String> = []
+
+                if let (installedSourceKeyStream, total) = await SourceManager.shared.installExternalSources(keys: missingSourceKeys) {
+                    var current = 0
+                    for await key in installedSourceKeyStream {
+                        current += 1
+                        installedSourceKeys.insert(key)
+                        await UIApplication.shared.appDelegate?.updateLoadingIndicator(
+                            progress: Float(current - 1) / Float(total)
+                        )
+                    }
                 }
 
-                // Newly installed sources were not eligible during the initial settings restore.
                 await restoreSettings(from: backup, sourceKeys: installedSourceKeys)
 
                 await Task { @MainActor in
-                    UIApplication.shared.appDelegate?.updateLoadingIndicator(
-                        message: NSLocalizedString("INSTALLING_SOURCES"),
-                        progress: 1
-                    )
-                    await UIApplication.shared.appDelegate?.hideLoadingIndicator()
+                    let appDelegate = UIApplication.shared.appDelegate
+                    appDelegate?.updateLoadingIndicator(progress: 1)
+                    await appDelegate?.hideLoadingIndicator()
                     UIApplication.shared.isIdleTimerDisabled = false
                 }.value
             }
@@ -625,6 +620,9 @@ extension BackupManager {
         NotificationCenter.default.post(name: .updateTrackers, object: nil)
         NotificationCenter.default.post(name: .updateCategories, object: nil)
         NotificationCenter.default.post(name: .updateLibrary, object: nil)
+
+        let backupSourceKeys = backup.sources?.map { $0.id } ?? []
+        let missingSourceKeys = await SourceManager.shared.missingExternalSourceKeys(in: Set(backupSourceKeys))
 
         await Task { @MainActor [backupError] in
             let delegate = UIApplication.shared.appDelegate
@@ -639,13 +637,10 @@ extension BackupManager {
                 )
             } else {
                 // show missing sources alert if there are any
-                let missingSources = (backup.sources ?? []).filter {
-                    !CoreDataManager.shared.hasSource(key: $0.id)
-                }
-                if !missingSources.isEmpty {
+                if !missingSourceKeys.isEmpty {
                     delegate?.presentAlert(
                         title: NSLocalizedString("MISSING_SOURCES"),
-                        message: NSLocalizedString("MISSING_SOURCES_TEXT") + missingSources.map { "\n- \($0.id)" }.joined()
+                        message: NSLocalizedString("MISSING_SOURCES_TEXT") + missingSourceKeys.map { "\n\($0)" }.joined()
                     )
                 }
             }
@@ -661,7 +656,7 @@ extension BackupManager {
         if let sourceKeys {
             sourceKeyPrefixes = sourceKeys.map { "\($0)." }
         } else {
-            // Only restore source settings for sources installed, or built-in sources added by the restore.
+            // only restore source settings for sources installed, or built-in sources that will be added from the backup restore
             let sources = await SourceManager.shared.getSourceInfos(sorted: false)
             sourceKeyPrefixes = sources.map { "\($0.sourceId)." } + (backup.sources ?? []).compactMap {
                 $0.config == nil ? nil : "\($0.id)."
@@ -669,6 +664,7 @@ extension BackupManager {
         }
 
         var needsMigrate = false
+
         for (key, value) in settings {
             let hasAllowedPrefix = (sourceKeys == nil && Self.allowedSettingsPrefixes.contains { key.hasPrefix($0) })
                 || sourceKeyPrefixes.contains { key.hasPrefix($0) }
@@ -693,11 +689,7 @@ extension BackupManager {
     }
 
     private func confirmExternalSourceRestore(keys: Set<String>) async -> Bool {
-        let message = String(
-            format: NSLocalizedString("RESTORE_MISSING_SOURCES_TEXT_%@"),
-            String(keys.count)
-        )
-            + keys.sorted().map { "\n- \($0)" }.joined()
+        let message = NSLocalizedString("RESTORE_MISSING_SOURCES_TEXT") + keys.sorted().map { "\n\($0)" }.joined()
 
         return await withCheckedContinuation { continuation in
             Task { @MainActor in

--- a/Aidoku/Core/Sources/SourceManager.swift
+++ b/Aidoku/Core/Sources/SourceManager.swift
@@ -370,6 +370,71 @@ extension SourceManager {
 
 // MARK: - Source Management
 extension SourceManager {
+    func missingExternalSourceKeys(in keys: Set<String>) async -> Set<String> {
+        let installedKeys: Set<String> = await CoreDataManager.shared.container.performBackgroundTask { context in
+            Set(CoreDataManager.shared.getSources(context: context).compactMap(\.id))
+        }
+        return keys.subtracting(installedKeys)
+    }
+
+    /// Installs missing sources with matching entries in the currently loaded source lists.
+    ///
+    /// If multiple lists contain the same source, the newest compatible version is used.
+    func installExternalSources(
+        keys: Set<String>,
+        progressReport: @MainActor @Sendable (_ name: String, _ key: String, _ current: Int, _ total: Int) -> Void
+    ) async -> Set<String> {
+        guard
+            !keys.isEmpty,
+            let appVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        else {
+            return []
+        }
+
+        let missingKeys = await missingExternalSourceKeys(in: keys)
+        guard !missingKeys.isEmpty else { return [] }
+
+        let appVersion = SemanticVersion(appVersionString)
+        var sourcesByKey: [String: ExternalSourceInfo] = [:]
+
+        for state in sourceListStates.values {
+            guard case let .loaded(sourceList) = state else { continue }
+            for source in sourceList.sources where missingKeys.contains(source.id) && source.fileURL != nil {
+                if
+                    let minAppVersion = source.minAppVersion.flatMap(SemanticVersion.init),
+                    minAppVersion > appVersion
+                {
+                    continue
+                }
+                if
+                    let maxAppVersion = source.maxAppVersion.flatMap(SemanticVersion.init),
+                    maxAppVersion < appVersion
+                {
+                    continue
+                }
+
+                if let existing = sourcesByKey[source.id] {
+                    if source.version > existing.version {
+                        sourcesByKey[source.id] = source
+                    }
+                } else {
+                    sourcesByKey[source.id] = source
+                }
+            }
+        }
+
+        let sources = missingKeys.sorted().compactMap { sourcesByKey[$0] }
+        var installedKeys: Set<String> = []
+        for (index, source) in sources.enumerated() {
+            guard let url = source.fileURL else { continue }
+            await progressReport(source.name, source.id, index + 1, sources.count)
+            if let installedSource = await importSource(from: url) {
+                installedKeys.insert(installedSource.key)
+            }
+        }
+        return installedKeys
+    }
+
     func importSource(from url: URL) async -> AidokuRunner.Source? {
         // download and unzip source aix
         guard let temporaryDirectory = FileManager.default.createTemporaryDirectory() else { return nil }

--- a/Aidoku/Core/Sources/SourceManager.swift
+++ b/Aidoku/Core/Sources/SourceManager.swift
@@ -377,42 +377,39 @@ extension SourceManager {
         return keys.subtracting(installedKeys)
     }
 
-    /// Installs missing sources with matching entries in the currently loaded source lists.
-    ///
-    /// If multiple lists contain the same source, the newest compatible version is used.
-    func installExternalSources(
-        keys: Set<String>,
-        progressReport: @MainActor @Sendable (_ name: String, _ key: String, _ current: Int, _ total: Int) -> Void
-    ) async -> Set<String> {
+    func installExternalSources(keys: Set<String>) async -> (AsyncStream<String>, Int)? {
         guard
             !keys.isEmpty,
             let appVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-        else {
-            return []
+                else {
+            return nil
         }
 
         let missingKeys = await missingExternalSourceKeys(in: keys)
-        guard !missingKeys.isEmpty else { return [] }
+        guard !missingKeys.isEmpty else { return nil }
+
+        let (stream, continuation) = AsyncStream<String>.makeStream()
 
         let appVersion = SemanticVersion(appVersionString)
         var sourcesByKey: [String: ExternalSourceInfo] = [:]
 
         for state in sourceListStates.values {
             guard case let .loaded(sourceList) = state else { continue }
-            for source in sourceList.sources where missingKeys.contains(source.id) && source.fileURL != nil {
-                if
-                    let minAppVersion = source.minAppVersion.flatMap(SemanticVersion.init),
-                    minAppVersion > appVersion
-                {
-                    continue
-                }
-                if
-                    let maxAppVersion = source.maxAppVersion.flatMap(SemanticVersion.init),
-                    maxAppVersion < appVersion
-                {
-                    continue
-                }
 
+            for source in sourceList.sources where missingKeys.contains(source.id) && source.fileURL != nil {
+                // check version availability
+                if let minAppVersion = source.minAppVersion {
+                    let minAppVersion = SemanticVersion(minAppVersion)
+                    if minAppVersion > appVersion {
+                        continue
+                    }
+                }
+                if let maxAppVersion = source.maxAppVersion {
+                    let maxAppVersion = SemanticVersion(maxAppVersion)
+                    if maxAppVersion < appVersion {
+                        continue
+                    }
+                }
                 if let existing = sourcesByKey[source.id] {
                     if source.version > existing.version {
                         sourcesByKey[source.id] = source
@@ -424,15 +421,18 @@ extension SourceManager {
         }
 
         let sources = missingKeys.sorted().compactMap { sourcesByKey[$0] }
-        var installedKeys: Set<String> = []
-        for (index, source) in sources.enumerated() {
-            guard let url = source.fileURL else { continue }
-            await progressReport(source.name, source.id, index + 1, sources.count)
-            if let installedSource = await importSource(from: url) {
-                installedKeys.insert(installedSource.key)
+
+        Task {
+            for source in sources {
+                guard let url = source.fileURL else { continue }
+                if await importSource(from: url) != nil {
+                    continuation.yield(source.id)
+                }
             }
+            continuation.finish()
         }
-        return installedKeys
+
+        return (stream, sources.count)
     }
 
     func importSource(from url: URL) async -> AidokuRunner.Source? {


### PR DESCRIPTION
The new sequence of tasks during restore: 

1. Restore source lists.
2. Finds missing source IDs in the restored lists and reinstall them.
 3. Query the now-installed sources.
 4. Restore settings whose keys begin with those source IDs.