### PR TITLE
feat: allow image prefetching beyond current chapter boundary

### DIFF
--- a/Aidoku/Features/Reader/Page/ReaderPageView.swift
+++ b/Aidoku/Features/Reader/Page/ReaderPageView.swift
@@ -182,6 +182,8 @@ extension ReaderPageView {
         var usePageProcessor = false
         if let source {
             // only process pages if the source supports it and the image isn't downloaded
+            // note: also skips processing raw data pages (assuming final data is already provided and doesn't need to be modified)
+            //       this should probably be changed in the future to be more correct though
             if source.features.processesPages, !url.isFileURL {
                 processors.append(PageInterceptorProcessor(source: source, pageContext: context))
                 usePageProcessor = true

--- a/Aidoku/Features/Reader/Page/ReaderPageView.swift
+++ b/Aidoku/Features/Reader/Page/ReaderPageView.swift
@@ -161,6 +161,48 @@ extension ReaderPageView {
         }
     }
 
+    /// Creates the image request used to fetch a page image.
+    static func imageRequest(url: URL, context: PageContext? = nil, sourceId: String? = nil) async -> ImageRequest {
+        let source: AidokuRunner.Source? = if let sourceId {
+            await SourceManager.shared.source(for: sourceId)
+        } else {
+            nil
+        }
+        return await imageRequest(url: url, context: context, source: source)
+    }
+
+    static func imageRequest(url: URL, context: PageContext? = nil, source: AidokuRunner.Source?) async -> ImageRequest {
+        let urlRequest = if !url.isFileURL, let source {
+            await source.getModifiedImageRequest(url: url, context: context)
+        } else {
+            URLRequest(url: url)
+        }
+
+        var processors: [ImageProcessing] = []
+        var usePageProcessor = false
+        if let source {
+            // only process pages if the source supports it and the image isn't downloaded
+            if source.features.processesPages, !url.isFileURL {
+                processors.append(PageInterceptorProcessor(source: source, pageContext: context))
+                usePageProcessor = true
+            }
+        }
+        if UserDefaults.standard.bool(forKey: "Reader.cropBorders") {
+            processors.append(CropBordersProcessor())
+        }
+        if UserDefaults.standard.bool(forKey: "Reader.downsampleImages") {
+            processors.append(DownsampleProcessor(width: UIScreen.main.bounds.width))
+        } else if UserDefaults.standard.bool(forKey: "Reader.upscaleImages") {
+            processors.append(UpscaleProcessor())
+        }
+
+        return ImageRequest(
+            urlRequest: urlRequest,
+            processors: processors,
+            userInfo: [.processesKey: usePageProcessor]
+        )
+    }
+
     func setPageImage(url: URL, context: PageContext? = nil, sourceId: String? = nil) async -> Bool {
         // remove text view if it exists
         if let textView {
@@ -193,42 +235,7 @@ extension ReaderPageView {
                     request = imageTask.request
             }
         } else {
-            let source: AidokuRunner.Source? = if let sourceId {
-                await SourceManager.shared.source(for: sourceId)
-            } else {
-                nil
-            }
-            let urlRequest = if !url.isFileURL, let source {
-                await source.getModifiedImageRequest(url: url, context: context)
-            } else {
-                URLRequest(url: url)
-            }
-
-            var processors: [ImageProcessing] = []
-            var usePageProcessor = false
-            if let source {
-                // only process pages if the source supports it and the image isn't downloaded
-                // note: also skips processing raw data pages (assuming final data is already provided and doesn't need to be modified)
-                //       this should probably be changed in the future to be more correct though
-                if source.features.processesPages, !url.isFileURL {
-                    processors.append(PageInterceptorProcessor(source: source, pageContext: context))
-                    usePageProcessor = true
-                }
-            }
-            if UserDefaults.standard.bool(forKey: "Reader.cropBorders") {
-                processors.append(CropBordersProcessor())
-            }
-            if UserDefaults.standard.bool(forKey: "Reader.downsampleImages") {
-                processors.append(DownsampleProcessor(width: UIScreen.main.bounds.width))
-            } else if UserDefaults.standard.bool(forKey: "Reader.upscaleImages") {
-                processors.append(UpscaleProcessor())
-            }
-
-            request = ImageRequest(
-                urlRequest: urlRequest,
-                processors: processors,
-                userInfo: [.processesKey: usePageProcessor]
-            )
+            request = await Self.imageRequest(url: url, context: context, sourceId: sourceId)
         }
 
         // Store current image request for reload functionality

--- a/Aidoku/Features/Reader/Page/ReaderPageView.swift
+++ b/Aidoku/Features/Reader/Page/ReaderPageView.swift
@@ -162,9 +162,9 @@ extension ReaderPageView {
     }
 
     /// Creates the image request used to fetch a page image.
-    static func imageRequest(url: URL, context: PageContext? = nil, sourceId: String? = nil) async -> ImageRequest {
-        let source: AidokuRunner.Source? = if let sourceId {
-            await SourceManager.shared.source(for: sourceId)
+    static func imageRequest(url: URL, context: PageContext? = nil, sourceKey: String? = nil) async -> ImageRequest {
+        let source: AidokuRunner.Source? = if let sourceKey {
+            await SourceManager.shared.source(for: sourceKey)
         } else {
             nil
         }
@@ -237,7 +237,7 @@ extension ReaderPageView {
                     request = imageTask.request
             }
         } else {
-            request = await Self.imageRequest(url: url, context: context, sourceId: sourceId)
+            request = await Self.imageRequest(url: url, context: context, sourceKey: sourceId)
         }
 
         // Store current image request for reload functionality

--- a/Aidoku/Features/Reader/ReaderPagePrefetcher.swift
+++ b/Aidoku/Features/Reader/ReaderPagePrefetcher.swift
@@ -20,7 +20,7 @@ final class ReaderPagePrefetcher {
     private var generation = 0
 
     /// Fetch the first `count` pages of a chapter, skipping any that were already requested.
-    func prefetch(pages: [Page], count: Int, chapterKey: String, sourceId: String) async {
+    func prefetch(pages: [Page], count: Int, chapterKey: String, sourceKey: String) async {
         let target = min(count, pages.count)
         let start = prefetchedCounts[chapterKey] ?? 0
         guard target > start else { return }
@@ -28,7 +28,7 @@ final class ReaderPagePrefetcher {
         prefetchedCounts[chapterKey] = target
 
         let generation = generation
-        let source = await SourceManager.shared.source(for: sourceId)
+        let source = await SourceManager.shared.source(for: sourceKey)
 
         var requests: [ImageRequest] = []
         for page in pages[start..<target] {

--- a/Aidoku/Features/Reader/ReaderPagePrefetcher.swift
+++ b/Aidoku/Features/Reader/ReaderPagePrefetcher.swift
@@ -1,0 +1,55 @@
+//
+//  ReaderPagePrefetcher.swift
+//  Aidoku
+//
+//  Created by Amqx on 8/26/26.
+//
+
+import AidokuRunner
+import Foundation
+import Nuke
+
+/// Fetches page image data into the disk cache before a page view exists to display them.
+@MainActor
+final class ReaderPagePrefetcher {
+    private let prefetcher = ImagePrefetcher(pipeline: .shared, destination: .diskCache)
+
+    /// The number of pages already handed to the prefetcher, per chapter key.
+    private var prefetchedCounts: [String: Int] = [:]
+    /// Incremented on reset, to drop fetches that were being prepared at the time.
+    private var generation = 0
+
+    /// Fetch the first `count` pages of a chapter, skipping any that were already requested.
+    func prefetch(pages: [Page], count: Int, chapterKey: String, sourceId: String) async {
+        let target = min(count, pages.count)
+        let start = prefetchedCounts[chapterKey] ?? 0
+        guard target > start else { return }
+        // mark these as requested up front, since building the requests suspends
+        prefetchedCounts[chapterKey] = target
+
+        let generation = generation
+        let source = await SourceManager.shared.source(for: sourceId)
+
+        var requests: [ImageRequest] = []
+        for page in pages[start..<target] {
+            guard
+                page.image == nil,
+                page.zipURL == nil,
+                let imageURL = page.imageURL,
+                let url = URL(string: imageURL),
+                !url.isFileURL
+            else { continue }
+            requests.append(await ReaderPageView.imageRequest(url: url, context: page.context, source: source))
+        }
+
+        guard !requests.isEmpty, generation == self.generation else { return }
+        prefetcher.startPrefetching(with: requests)
+    }
+
+    /// Cancel outstanding fetches and forget what's been requested.
+    func reset() {
+        generation += 1
+        prefetcher.stopPrefetching()
+        prefetchedCounts.removeAll()
+    }
+}

--- a/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
+++ b/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
@@ -477,14 +477,14 @@ extension ReaderPagedViewController {
                 let previewController = pageViewControllers.last,
                 case .page = previewController.type
             {
-                previewController.setPage(firstPage, sourceId: sourceId)
+                previewController.setPage(firstPage, sourceId: sourceKey)
             }
 
             await pagePrefetcher.prefetch(
                 pages: pages,
                 count: pageCount,
                 chapterKey: nextChapter.key,
-                sourceId: sourceId
+                sourceKey: sourceKey
             )
         }
     }

--- a/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
+++ b/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
@@ -470,7 +470,7 @@ extension ReaderPagedViewController {
 
             let pages = viewModel.preloadedPages
             guard !pages.isEmpty else { return }
-            let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
+            let sourceKey = viewModel.manga.sourceKey
 
             if
                 let firstPage = pages.first,

--- a/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
+++ b/Aidoku/Features/Reader/Readers/Paged/ReaderPagedViewController.swift
@@ -42,6 +42,8 @@ class ReaderPagedViewController: BaseObservingViewController {
     private var isolatedPages: Set<Int> = []
     private var manuallyIsolatedPages: Set<Int> = []
     private lazy var pagesToPreload = UserDefaults.standard.integer(forKey: "Reader.pagesToPreload")
+    private let pagePrefetcher = ReaderPagePrefetcher()
+    private var nextChapterPreloadTask: Task<Void, Never>?
 
     // Split pages tracking
     private var actualPageIndices: [Int] = []
@@ -104,6 +106,7 @@ class ReaderPagedViewController: BaseObservingViewController {
             // clear pages that aren't in the preload range if we get a memory warning
             LogManager.logger.warn("Received memory warning")
             Self.clearSplitPageCache()
+            self?.pagePrefetcher.reset()
             guard
                 let self,
                 let viewController = pageViewController.viewControllers?.first,
@@ -440,6 +443,49 @@ extension ReaderPagedViewController {
             guard i > 0 else { continue }
             guard i <= displayPageCount else { break }
             loadPage(at: i)
+        }
+        // allow prefetching into the next chapter
+        if range.upperBound > displayPageCount {
+            preloadNextChapter(pageCount: min(range.upperBound - displayPageCount, pagesToPreload))
+        }
+    }
+
+    /// Fetch the first `pageCount` pages of the next chapter ahead of time.
+    func preloadNextChapter(pageCount: Int) {
+        guard pageCount > 0, let nextChapter else { return }
+
+        let previousTask = nextChapterPreloadTask
+        nextChapterPreloadTask = Task { [weak self] in
+            // preloads run one at a time so a wider range doesn't duplicate a narrower one in flight
+            await previousTask?.value
+            guard let self, !Task.isCancelled, nextChapter == self.nextChapter else { return }
+
+            await viewModel.preload(chapter: nextChapter)
+
+            guard
+                !Task.isCancelled,
+                nextChapter == self.nextChapter,
+                viewModel.preloadedChapter == nextChapter
+            else { return }
+
+            let pages = viewModel.preloadedPages
+            guard !pages.isEmpty else { return }
+            let sourceId = viewModel.source?.key ?? viewModel.manga.sourceKey
+
+            if
+                let firstPage = pages.first,
+                let previewController = pageViewControllers.last,
+                case .page = previewController.type
+            {
+                previewController.setPage(firstPage, sourceId: sourceId)
+            }
+
+            await pagePrefetcher.prefetch(
+                pages: pages,
+                count: pageCount,
+                chapterKey: nextChapter.key,
+                sourceId: sourceId
+            )
         }
     }
 
@@ -847,6 +893,12 @@ extension ReaderPagedViewController: ReaderReaderDelegate {
 
     func setChapter(_ chapter: AidokuRunner.Chapter, startPage: Int) {
         let isChapterChange = self.chapter?.id != chapter.id
+        if isChapterChange {
+            nextChapterPreloadTask?.cancel()
+            if chapter != nextChapter {
+                pagePrefetcher.reset()
+            }
+        }
         self.chapter = chapter
         Task {
             await loadChapter(startPage: startPage, isChapterChange: isChapterChange)
@@ -967,17 +1019,7 @@ extension ReaderPagedViewController: UIPageViewControllerDelegate {
             case displayPageCount + 1: // next chapter transition page
                 delegate?.setCurrentPage(displayPageCount + 1, position: nil)
                 // preload next
-                if let nextChapter = nextChapter {
-                    Task {
-                        await viewModel.preload(chapter: nextChapter)
-                        if currentIndex + 1 < pageViewControllers.count, let firstPage = viewModel.preloadedPages.first {
-                            pageViewControllers[currentIndex + 1].setPage(
-                                firstPage,
-                                sourceId: viewModel.source?.key ?? viewModel.manga.sourceKey
-                            )
-                        }
-                    }
-                }
+                preloadNextChapter(pageCount: pagesToPreload)
 
             case displayPageCount + 2: // next chapter first page
                 pendingSpreadRebuild = false

--- a/Aidoku/Features/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
+++ b/Aidoku/Features/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
@@ -27,6 +27,8 @@ class ReaderWebtoonViewController: ZoomableCollectionViewController {
 
     // Indicates if infinite scroll is enabled
     private lazy var infinite = UserDefaults.standard.bool(forKey: "Reader.verticalInfiniteScroll")
+    // How many pages before the end of the last chapter the next one starts loading
+    private lazy var pagesToPreload = UserDefaults.standard.integer(forKey: "Reader.pagesToPreload")
     private var loadingPrevious = false
     private var loadingNext = false
 
@@ -141,6 +143,10 @@ class ReaderWebtoonViewController: ZoomableCollectionViewController {
             addObserver(forName: key) { [weak self] _ in
                 self?.updateDoubleTapZoomSetting()
             }
+        }
+        addObserver(forName: "Reader.pagesToPreload") { [weak self] notification in
+            self?.pagesToPreload = notification.object as? Int
+                ?? UserDefaults.standard.integer(forKey: "Reader.pagesToPreload")
         }
         addObserver(forName: .readerShowingBars) { [weak self] _ in
             self?.setLiveTextButtonHidden(false)
@@ -553,12 +559,30 @@ extension ReaderWebtoonViewController {
                 }
             }
         }
+        // a missing path means the bottom of the screen is past the last page
+        let bottomPath = getCurrentPagePath(pos: .bottom)
+
+        // mark the current chapter completed at the end of its own section, which isn't
+        // necessarily the last one now that the next chapter can be appended early
+        if
+            let chapter,
+            let chapterIndex = chapters.firstIndex(of: chapter),
+            let chapterPages = pages[safe: chapterIndex],
+            bottomPath == nil || (bottomPath?.section == chapterIndex && bottomPath?.item == chapterPages.count - 1)
+        {
+            delegate?.setCompleted()
+        }
+
         if !loadingNext {
-            let bottomPath = getCurrentPagePath(pos: .bottom)
-            // append next chapter
-            if bottomPath == nil || (bottomPath?.section == pages.count - 1 && bottomPath?.item == pages[pages.count - 1].count - 1) {
+            let lastSection = pages.count - 1
+            let lastItem = (pages.last?.count ?? 0) - 1
+            let atEnd = bottomPath == nil || (bottomPath?.section == lastSection && bottomPath?.item == lastItem)
+            // append the next chapter before reaching the end, so its pages have time to load
+            let withinPreloadRange = bottomPath?.section == lastSection
+                && lastItem - (bottomPath?.item ?? lastItem) <= pagesToPreload
+
+            if atEnd || withinPreloadRange {
                 loadingNext = true
-                delegate?.setCompleted()
                 Task {
                     await appendNextChapter()
                     loadingNext = false
@@ -623,6 +647,7 @@ extension ReaderWebtoonViewController {
     /// Append the next chapter's pages
     func appendNextChapter() async {
         guard let nextChapter = delegate?.getNextChapter() else { return }
+        guard !chapters.contains(nextChapter) else { return }
         await viewModel.preload(chapter: nextChapter)
 
         // check if pages failed to load


### PR DESCRIPTION
Allow the paged readers to prefetch past the current chapter boundary.

The paged readers can reduce the amount of time waiting on the chapter transition screen, since image loading work can begin in the previous chapter. Note that this only looks one chapter ahead, even if the user's configured prefetch limit is higher than the total number of images loaded.