### PR TITLE
fix: make manga cover view dismissible by swipe

### DIFF
--- a/Aidoku/Features/Manga/MangaCoverPageView.swift
+++ b/Aidoku/Features/Manga/MangaCoverPageView.swift
@@ -21,7 +21,6 @@ struct MangaCoverPageView: View {
 
     @State private var showImagePicker = false
     @State private var uploadedCover: UIImage?
-    @State private var dismissDragOffset: CGFloat = 0
 
     @Environment(\.dismiss) private var dismiss
 
@@ -126,33 +125,6 @@ struct MangaCoverPageView: View {
                 await loadCovers()
             }
         }
-        .offset(y: dismissDragOffset)
-        .simultaneousGesture(dismissGesture)
-    }
-
-    private var dismissGesture: some Gesture {
-        DragGesture(minimumDistance: 20)
-            .onChanged { value in
-                let translation = value.translation
-                guard translation.height > abs(translation.width) else {
-                    dismissDragOffset = 0
-                    return
-                }
-                dismissDragOffset = translation.height
-            }
-            .onEnded { value in
-                let translation = value.translation
-                let isVerticalSwipe = translation.height > abs(translation.width)
-                let shouldDismiss = translation.height > 100 || value.predictedEndTranslation.height > 180
-
-                if isVerticalSwipe && shouldDismiss {
-                    dismiss()
-                } else {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        dismissDragOffset = 0
-                    }
-                }
-            }
     }
 
     func view(coverImage: String) -> some View {

--- a/Aidoku/Features/Manga/MangaCoverPageView.swift
+++ b/Aidoku/Features/Manga/MangaCoverPageView.swift
@@ -21,6 +21,7 @@ struct MangaCoverPageView: View {
 
     @State private var showImagePicker = false
     @State private var uploadedCover: UIImage?
+    @State private var dismissDragOffset: CGFloat = 0
 
     @Environment(\.dismiss) private var dismiss
 
@@ -125,6 +126,33 @@ struct MangaCoverPageView: View {
                 await loadCovers()
             }
         }
+        .offset(y: dismissDragOffset)
+        .simultaneousGesture(dismissGesture)
+    }
+
+    private var dismissGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onChanged { value in
+                let translation = value.translation
+                guard translation.height > abs(translation.width) else {
+                    dismissDragOffset = 0
+                    return
+                }
+                dismissDragOffset = translation.height
+            }
+            .onEnded { value in
+                let translation = value.translation
+                let isVerticalSwipe = translation.height > abs(translation.width)
+                let shouldDismiss = translation.height > 100 || value.predictedEndTranslation.height > 180
+
+                if isVerticalSwipe && shouldDismiss {
+                    dismiss()
+                } else {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        dismissDragOffset = 0
+                    }
+                }
+            }
     }
 
     func view(coverImage: String) -> some View {

--- a/Aidoku/Features/Manga/MangaDetailsHeaderView.swift
+++ b/Aidoku/Features/Manga/MangaDetailsHeaderView.swift
@@ -36,6 +36,7 @@ struct MangaDetailsHeaderView: View {
     @Binding var chapterTitleDisplayMode: ChapterTitleDisplayMode
 
     var hasOtherDownloads: Bool
+    var transitionNamespace: Namespace.ID
     var onTrackerButtonPressed: (() -> Void)?
     var onReadButtonPressed: (() -> Void)?
 
@@ -71,6 +72,7 @@ struct MangaDetailsHeaderView: View {
         descriptionExpanded: Binding<Bool>,
         chapterTitleDisplayMode: Binding<ChapterTitleDisplayMode>,
         hasOtherDownloads: Bool,
+        transitionNamespace: Namespace.ID,
         onTrackerButtonPressed: (() -> Void)? = nil,
         onReadButtonPressed: (() -> Void)? = nil
     ) {
@@ -92,6 +94,7 @@ struct MangaDetailsHeaderView: View {
         self._descriptionExpanded = descriptionExpanded
         self._chapterTitleDisplayMode = chapterTitleDisplayMode
         self.hasOtherDownloads = hasOtherDownloads
+        self.transitionNamespace = transitionNamespace
         self.onTrackerButtonPressed = onTrackerButtonPressed
         self.onReadButtonPressed = onReadButtonPressed
 
@@ -120,6 +123,7 @@ struct MangaDetailsHeaderView: View {
                     }
                     .buttonStyle(DarkOverlayButtonStyle())
                     .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                    .matchedTransitionSourcePlease(id: manga.identifier, in: transitionNamespace)
                 }
 
                 VStack(alignment: .leading, spacing: 0) {
@@ -545,6 +549,7 @@ private struct MangaActionButtonStyle: ButtonStyle {
     @Previewable @State var langFilter: String?
     @Previewable @State var scanlatorFilter: [String] = []
     @Previewable @State var chapterTitleDisplayMode = ChapterTitleDisplayMode.default
+    @Previewable @Namespace var transitionNamespace
 
     MangaDetailsHeaderView(
         source: Binding.constant(AidokuRunner.Source.demo()),
@@ -571,5 +576,6 @@ private struct MangaActionButtonStyle: ButtonStyle {
         descriptionExpanded: Binding.constant(false),
         chapterTitleDisplayMode: $chapterTitleDisplayMode,
         hasOtherDownloads: false,
+        transitionNamespace: transitionNamespace,
     )
 }

--- a/Aidoku/Features/Manga/MangaView.swift
+++ b/Aidoku/Features/Manga/MangaView.swift
@@ -174,6 +174,7 @@ struct MangaView: View {
                     source: viewModel.source,
                     manga: viewModel.manga
                 )
+                .navigationTransitionZoom(sourceID: viewModel.manga.identifier, in: transitionNamespace)
             }
             .task {
                 guard !detailsLoaded else { return }
@@ -296,6 +297,7 @@ extension MangaView {
                 descriptionExpanded: $descriptionExpanded,
                 chapterTitleDisplayMode: $viewModel.chapterTitleDisplayMode,
                 hasOtherDownloads: !viewModel.otherDownloadedChapters.isEmpty,
+                transitionNamespace: transitionNamespace,
                 onTrackerButtonPressed: {
                     let vc = TrackerModalViewController(manga: viewModel.manga)
                     vc.modalPresentationStyle = .overFullScreen


### PR DESCRIPTION
The fullscreen manga cover view could only get closed by clicking the `x` at the top. 

This PR adds an additional swipe gesture allowing it to be dismissed by swiping down. 