### PR TITLE
fix: memory warning no longer perma degrades webtoon reader performance

### DIFF
--- a/Aidoku/Features/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
+++ b/Aidoku/Features/Reader/Readers/Webtoon/ReaderWebtoonViewController.swift
@@ -195,6 +195,11 @@ class ReaderWebtoonViewController: ZoomableCollectionViewController {
         )
     }
 
+    /// Put the collection node back into the full preload range.
+    private func restorePreloadRange() {
+        (collectionNode as ASRangeControllerUpdateRangeProtocol).updateCurrentRange(with: .full)
+    }
+
     private func setLiveTextButtonHidden(_ hidden: Bool) {
         collectionNode.visibleNodes.forEach {
             guard let pageNode = $0 as? ReaderWebtoonPageNode else { return }
@@ -272,6 +277,8 @@ extension ReaderWebtoonViewController {
             return
         }
 
+        restorePreloadRange()
+
         let speed = max(UserDefaults.standard.integer(forKey: "Reader.autoScrollSpeed"), 1)
         let distance = CGFloat(speed * 100) * CGFloat(displayLink.timestamp - previousTimestamp)
         let minimumY = -scrollView.adjustedContentInset.top
@@ -298,6 +305,7 @@ extension ReaderWebtoonViewController {
 extension ReaderWebtoonViewController {
     override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         super.scrollViewWillBeginDragging(scrollView)
+        restorePreloadRange()
         pauseAutoScroll()
         setLiveTextButtonHidden(true)
     }


### PR DESCRIPTION
right now a memory warning permanently degrades the webtoon reader's performance

it's a little annoying to describe with text, but you can easily reproduce

1. start reading in webtoon mode on simulator
2. simulate a memory warning (Simulator > Debug > Simulate Memory Warning)
3. reading permanently degrades

to do this on a real phone just read like 20 chapters of webtoons so enough pages get loaded to cause a memory error

this is because all the pages are stored in memory and never cleared. texture then degrades into this state and cannot self-recover. i noticed that a fix for this was attempted a few years back where only three chapters could get loaded at once so this memory warning wouldn't occur but just like before your attempt i couldn't get it to work nicely. this is the fastest 1 liner fix but it still has the problem of memory climbing as you read more and more. 


your choice if you want to merge this alone rn or wait and try to figure out the other thing. in the meantime this resolves the consequences of the issue, not the cause