### PR TITLE
fix: reduce core data remote history processing

### DIFF
--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -32,6 +32,12 @@ final class CoreDataManager: @unchecked Sendable {
     }()
     // only accessed from remoteHistoryQueue
     private var lastHistoryToken: NSPersistentHistoryToken?
+    private var didLoadHistoryToken = false
+
+    private static let historyTokenUrl = FileManager.default.applicationSupportDirectory
+        .appendingPathComponent("historyToken.data")
+    /// How far back a cold start looks when no token has been stored yet.
+    private static let historyColdStartWindow: TimeInterval = 24 * 60 * 60
 
     private static var shouldUseiCloud: Bool {
         AppSettings.general.icloudSync.get() && FileManager.default.ubiquityIdentityToken != nil
@@ -187,7 +193,12 @@ extension CoreDataManager {
             context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
             context.performAndWait {
                 let historyFetchRequest = NSPersistentHistoryTransaction.fetchRequest!
-                let request = NSPersistentHistoryChangeRequest.fetchHistory(after: self.lastHistoryToken)
+                let request: NSPersistentHistoryChangeRequest
+                if let token = self.historyToken() {
+                    request = .fetchHistory(after: token)
+                } else {
+                    request = .fetchHistory(after: Date().addingTimeInterval(-Self.historyColdStartWindow))
+                }
                 request.fetchRequest = historyFetchRequest
 
                 let result = (try? context.execute(request)) as? NSPersistentHistoryResult
@@ -222,9 +233,31 @@ extension CoreDataManager {
                     self.deduplicate(objectIds: newObjectIds)
                 }
 
-                self.lastHistoryToken = transactions.last!.token
+                self.setHistoryToken(transactions.last!.token)
             }
         }
+    }
+
+    private func historyToken() -> NSPersistentHistoryToken? {
+        if !didLoadHistoryToken {
+            didLoadHistoryToken = true
+            if let data = try? Data(contentsOf: Self.historyTokenUrl) {
+                lastHistoryToken = try? NSKeyedUnarchiver.unarchivedObject(
+                    ofClass: NSPersistentHistoryToken.self,
+                    from: data
+                )
+            }
+        }
+        return lastHistoryToken
+    }
+
+    private func setHistoryToken(_ token: NSPersistentHistoryToken) {
+        didLoadHistoryToken = true
+        lastHistoryToken = token
+        guard
+            let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+        else { return }
+        try? data.write(to: Self.historyTokenUrl, options: .atomic)
     }
 
     func deduplicate(objectIds: [NSManagedObjectID]) {

--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -33,17 +33,24 @@ final class CoreDataManager: @unchecked Sendable {
     // only accessed from remoteHistoryQueue
     private var lastHistoryToken: NSPersistentHistoryToken?
     private var didLoadHistoryToken = false
+    private var lastHistoryPurge: Date?
+    private let usesCloudKitMirroring: Bool
 
     private static let historyTokenUrl = FileManager.default.applicationSupportDirectory
         .appendingPathComponent("historyToken.data")
     /// How far back a cold start looks when no token has been stored yet.
     private static let historyColdStartWindow: TimeInterval = 24 * 60 * 60
+    /// How much history to keep around while mirroring is running, which needs it to export.
+    private static let historyRetention: TimeInterval = 7 * 24 * 60 * 60
+    /// Purging on every remote change notification would run once per save, so throttle it.
+    private static let historyPurgeInterval: TimeInterval = 60 * 60
 
     private static var shouldUseiCloud: Bool {
         AppSettings.general.icloudSync.get() && FileManager.default.ubiquityIdentityToken != nil
     }
 
     private init() {
+        self.usesCloudKitMirroring = Self.shouldUseiCloud
         self.container = Self.createContainer()
 
         NotificationCenter.default.publisher(
@@ -189,6 +196,10 @@ extension CoreDataManager {
     func storeRemoteChange() {
         remoteHistoryQueue.addOperation { [weak self] in
             guard let self else { return }
+            guard self.usesCloudKitMirroring else {
+                self.purgeHistory(before: Date())
+                return
+            }
             let context = self.container.newBackgroundContext()
             context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
             context.performAndWait {
@@ -201,7 +212,15 @@ extension CoreDataManager {
                 }
                 request.fetchRequest = historyFetchRequest
 
-                let result = (try? context.execute(request)) as? NSPersistentHistoryResult
+                var result = (try? context.execute(request)) as? NSPersistentHistoryResult
+                if result == nil && self.historyToken() != nil {
+                    self.clearHistoryToken()
+                    let fallback = NSPersistentHistoryChangeRequest.fetchHistory(
+                        after: Date().addingTimeInterval(-Self.historyColdStartWindow)
+                    )
+                    fallback.fetchRequest = historyFetchRequest
+                    result = (try? context.execute(fallback)) as? NSPersistentHistoryResult
+                }
                 guard
                     let transactions = result?.result as? [NSPersistentHistoryTransaction],
                     !transactions.isEmpty
@@ -235,6 +254,24 @@ extension CoreDataManager {
 
                 self.setHistoryToken(transactions.last!.token)
             }
+            self.purgeHistory(before: Date().addingTimeInterval(-Self.historyRetention))
+        }
+    }
+
+    private func purgeHistory(before date: Date) {
+        let now = Date()
+        if let lastHistoryPurge, now.timeIntervalSince(lastHistoryPurge) < Self.historyPurgeInterval {
+            return
+        }
+        lastHistoryPurge = now
+
+        let context = container.newBackgroundContext()
+        context.performAndWait {
+            do {
+                try context.execute(NSPersistentHistoryChangeRequest.deleteHistory(before: date))
+            } catch {
+                LogManager.logger.error("purgeHistory: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -249,6 +286,12 @@ extension CoreDataManager {
             }
         }
         return lastHistoryToken
+    }
+
+    private func clearHistoryToken() {
+        didLoadHistoryToken = true
+        lastHistoryToken = nil
+        try? FileManager.default.removeItem(at: Self.historyTokenUrl)
     }
 
     private func setHistoryToken(_ token: NSPersistentHistoryToken) {

--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -263,20 +263,24 @@ extension CoreDataManager {
     func deduplicate(objectIds: [NSManagedObjectID]) {
         let context = container.newBackgroundContext()
         context.mergePolicy = NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
-        context.performAndWait {
-            for objectId in objectIds {
-                deduplicate(objectId: objectId, context: context)
-            }
-            do {
-                try context.save()
-            } catch {
-                LogManager.logger.error("deduplicate: \(error.localizedDescription)")
+        // Work in batches, saving and resetting in between.
+        for batch in objectIds.chunked(into: 500) {
+            context.performAndWait {
+                for objectId in batch {
+                    deduplicate(objectId: objectId, context: context)
+                }
+                do {
+                    try context.save()
+                } catch {
+                    LogManager.logger.error("deduplicate: \(error.localizedDescription)")
+                }
+                context.reset()
             }
         }
     }
 
     func deduplicate(objectId: NSManagedObjectID, context: NSManagedObjectContext) {
-        let object = context.object(with: objectId)
+        guard let object = try? context.existingObject(with: objectId) else { return }
 
         let request: NSFetchRequest<NSFetchRequestResult>?
 

--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -34,7 +34,7 @@ final class CoreDataManager: @unchecked Sendable {
     private var lastHistoryToken: NSPersistentHistoryToken?
     private var didLoadHistoryToken = false
     private var lastHistoryPurge: Date?
-    private let usesCloudKitMirroring: Bool
+    private var usesCloudKitMirroring: Bool
 
     private static let historyTokenUrl = FileManager.default.applicationSupportDirectory
         .appendingPathComponent("historyToken.data")
@@ -50,8 +50,9 @@ final class CoreDataManager: @unchecked Sendable {
     }
 
     private init() {
-        self.usesCloudKitMirroring = Self.shouldUseiCloud
-        self.container = Self.createContainer()
+        let usesCloudKitMirroring = Self.shouldUseiCloud
+        self.usesCloudKitMirroring = usesCloudKitMirroring
+        self.container = Self.createContainer(usesCloudKitMirroring: usesCloudKitMirroring)
 
         NotificationCenter.default.publisher(
             for: .NSPersistentStoreRemoteChange,
@@ -62,7 +63,10 @@ final class CoreDataManager: @unchecked Sendable {
         }
         .store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: .init(AppSettings.general.icloudSync.key))
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: .init(AppSettings.general.icloudSync.key)),
+            NotificationCenter.default.publisher(for: NSNotification.Name.NSUbiquityIdentityDidChange)
+        )
             .sink { [weak self] _ in
                 Task { @MainActor in
                     self?.updateCloudConfiguration()
@@ -71,7 +75,7 @@ final class CoreDataManager: @unchecked Sendable {
             .store(in: &cancellables)
     }
 
-    static func createContainer() -> NSPersistentCloudKitContainer {
+    static func createContainer(usesCloudKitMirroring: Bool) -> NSPersistentCloudKitContainer {
         let container = NSPersistentCloudKitContainer(name: "Aidoku")
 
         let storeDirectory = FileManager.default.applicationSupportDirectory
@@ -89,7 +93,7 @@ final class CoreDataManager: @unchecked Sendable {
         localDescription.shouldMigrateStoreAutomatically = true
         localDescription.shouldInferMappingModelAutomatically = true
 
-        if shouldUseiCloud {
+        if usesCloudKitMirroring {
             cloudDescription.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(
                 containerIdentifier: CoreDataManager.containerID)
         } else {
@@ -154,8 +158,13 @@ final class CoreDataManager: @unchecked Sendable {
 
     @MainActor
     func updateCloudConfiguration() {
+        let usesCloudKitMirroring = Self.shouldUseiCloud
+        remoteHistoryQueue.addOperation { [weak self] in
+            self?.usesCloudKitMirroring = usesCloudKitMirroring
+        }
+
         guard let cloudDescription = self.container.persistentStoreDescriptions.first else { return }
-        if Self.shouldUseiCloud {
+        if usesCloudKitMirroring {
             cloudDescription.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(containerIdentifier: CoreDataManager.containerID)
         } else {
             cloudDescription.cloudKitContainerOptions = nil
@@ -291,7 +300,7 @@ extension CoreDataManager {
     private func clearHistoryToken() {
         didLoadHistoryToken = true
         lastHistoryToken = nil
-        try? FileManager.default.removeItem(at: Self.historyTokenUrl)
+        Self.historyTokenUrl.removeItem()
     }
 
     private func setHistoryToken(_ token: NSPersistentHistoryToken) {


### PR DESCRIPTION
a few problems with aidoku's core data history handling:

1. it only persists its history token in memory, so every startup it replayed the entire transaction history and runs deduplication over all of it in the background
     - this is really bad because iOS just kills your app off if it uses too much memory/ cpu in the background (how i found it in the first place)
2. it does it even if the user doesn't use icloud sync (which is off by force for side loaders)

this pr fixes the following:
- persists the token to disk, so later launches resume from where they left off (falls back to 24h window if missing token)
- skips processing the history entirely if icloud sync is off, then purges the history
- purges history older than 7 days when icloud sync is on since only the sync server needs it, not reader

the biggest win would just be to stop writing history if the user has icloud disabled but i haven't looked into that enough yet

i think this also addresses #1065
probably also [this](https://discord.com/channels/927984899472883723/932316297625235477/1545328405078212728)
and likely this as [well](https://discord.com/channels/927984899472883723/932316297625235477/1545317495295180873)