### PR TITLE
fix: preserve chapter download status when filtering

### DIFF
--- a/Aidoku/Features/Manga/MangaView+ViewModel.swift
+++ b/Aidoku/Features/Manga/MangaView+ViewModel.swift
@@ -600,7 +600,7 @@ extension MangaView.ViewModel {
     }
 
     private func loadDownloadStatus() async {
-        for chapter in chapters + otherDownloadedChapters {
+        for chapter in (manga.chapters ?? chapters) + otherDownloadedChapters {
             downloadStatus[chapter.key] = DownloadManager.shared.getDownloadStatus(
                 for: .init(sourceKey: manga.sourceKey, mangaKey: manga.key, chapterKey: chapter.key)
             )


### PR DESCRIPTION
## Summary

Fix an issue where a chapter's downloaded status disappears after changing the scanlator filter and reopening the manga page.

## Steps to reproduce

1. Open a manga and download a chapter.
2. Confirm that the downloaded chapter displays the download icon while it is included by the current scanlator filter.
3. Change the scanlator filter so that the downloaded chapter is excluded.
4. Exit the manga page.
5. Reopen the manga page.
6. Change the scanlator filter to include the downloaded chapter again.
7. The chapter is visible, but the download icon is missing.
8. Exit the manga page again.
9. Reopen the manga page.
10. The download icon is displayed again.

## Expected behavior

Whenever a downloaded chapter is included in the current scanlator filter, it should display the downloaded status immediately.

## Actual behavior

After reopening the page with the downloaded chapter excluded by the filter, including it again makes the chapter visible but does not restore its download icon. Reopening the page one more time restores the icon.

## Fix

Load download statuses from the manga's complete chapter list instead of only the currently filtered chapters.

## Tests

- [x] Build succeeded
- [x] Existing unit tests passed
- [x] Verified on a physical device

## Reproduction video

https://github.com/user-attachments/assets/decf17c5-4350-4968-9c9a-18a28cd6c54b
