### PR TITLE
feat: refresh library, manga, and history after iCloud sync changes

### DIFF
--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -243,6 +243,7 @@ extension CoreDataManager {
                 else { return }
 
                 var newObjectIds = [NSManagedObjectID]()
+                var shouldUpdateLibrary = false
                 let entityNames = [
                     CategoryObject.entity().name,
                     ChapterObject.entity().name,
@@ -258,9 +259,12 @@ extension CoreDataManager {
                 {
                     for
                         change in transaction.changes!
-                        where entityNames.contains(change.changedObjectID.entity.name) && change.changeType == .insert
+                        where entityNames.contains(change.changedObjectID.entity.name)
                     {
-                        newObjectIds.append(change.changedObjectID)
+                        shouldUpdateLibrary = true
+                        if change.changeType == .insert {
+                            newObjectIds.append(change.changedObjectID)
+                        }
                     }
                 }
 
@@ -269,6 +273,12 @@ extension CoreDataManager {
                 }
 
                 self.setHistoryToken(transactions.last!.token)
+
+                if shouldUpdateLibrary {
+                    Task { @MainActor in
+                        NotificationCenter.default.post(name: .updateLibrary, object: nil)
+                    }
+                }
             }
             self.purgeHistory(before: Date().addingTimeInterval(-Self.historyRetention))
         }

--- a/Aidoku/Core/Database/CoreDataManager.swift
+++ b/Aidoku/Core/Database/CoreDataManager.swift
@@ -244,6 +244,7 @@ extension CoreDataManager {
 
                 var newObjectIds = [NSManagedObjectID]()
                 var shouldUpdateLibrary = false
+                var shouldUpdateHistory = false
                 let entityNames = [
                     CategoryObject.entity().name,
                     ChapterObject.entity().name,
@@ -262,6 +263,9 @@ extension CoreDataManager {
                         where entityNames.contains(change.changedObjectID.entity.name)
                     {
                         shouldUpdateLibrary = true
+                        if change.changedObjectID.entity.name == HistoryObject.entity().name {
+                            shouldUpdateHistory = true
+                        }
                         if change.changeType == .insert {
                             newObjectIds.append(change.changedObjectID)
                         }
@@ -275,8 +279,11 @@ extension CoreDataManager {
                 self.setHistoryToken(transactions.last!.token)
 
                 if shouldUpdateLibrary {
-                    Task { @MainActor in
+                    Task { @MainActor [shouldUpdateHistory] in
                         NotificationCenter.default.post(name: .updateLibrary, object: nil)
+                        if shouldUpdateHistory {
+                            NotificationCenter.default.post(name: .updateHistory, object: nil)
+                        }
                     }
                 }
             }

--- a/Aidoku/Features/History/HistoryView+ViewModel.swift
+++ b/Aidoku/Features/History/HistoryView+ViewModel.swift
@@ -27,6 +27,7 @@ extension HistoryView {
         private var offset = 0
         private var historyData: [Int: [HistoryEntry]] = [:]
         private var loadTask: Task<Bool, Never>?
+        private var historyReloadGeneration = 0
 
         private var searchQuery: String = ""
         private var searchTask: Task<Void, Never>?
@@ -53,6 +54,7 @@ extension HistoryView.ViewModel {
                 guard let self else { return }
                 Task { @MainActor in
                     _ = await self.loadTask?.value
+                    self.historyReloadGeneration += 1
                     self.loadTask = nil
                     self.filteredHistory = [:]
                     self.historyData = [:]
@@ -173,6 +175,7 @@ extension HistoryView.ViewModel {
     func loadMore() async {
         guard loadingState == .idle else { return }
 
+        let generation = historyReloadGeneration
         loadingState = .loading
 
         if loadTask == nil {
@@ -184,6 +187,8 @@ extension HistoryView.ViewModel {
         }
         guard let loadTask else { return }
         let completed = await loadTask.value
+        // A refresh may have reset pagination while this task was suspended.
+        guard generation == historyReloadGeneration else { return }
         self.loadTask = nil
 
         loadingState = completed ? .complete : .idle

--- a/Aidoku/Features/History/HistoryView+ViewModel.swift
+++ b/Aidoku/Features/History/HistoryView+ViewModel.swift
@@ -52,6 +52,8 @@ extension HistoryView.ViewModel {
                 // reset all cached history entries
                 guard let self else { return }
                 Task { @MainActor in
+                    _ = await self.loadTask?.value
+                    self.loadTask = nil
                     self.filteredHistory = [:]
                     self.historyData = [:]
                     self.offset = 0

--- a/Aidoku/Features/Manga/MangaView+ViewModel.swift
+++ b/Aidoku/Features/Manga/MangaView+ViewModel.swift
@@ -86,9 +86,6 @@ extension MangaView.ViewModel {
                     guard let self else { return }
                     await self.loadBookmarked()
                     await self.checkForCategories()
-                    await self.loadHistory()
-                    self.chapters = self.filteredChapters()
-                    self.updateReadButton()
                 }
             }
             .store(in: &cancellables)
@@ -180,6 +177,7 @@ extension MangaView.ViewModel {
                 guard let self else { return }
                 Task { @MainActor in
                     await self.loadHistory()
+                    self.chapters = self.filteredChapters()
                     self.updateReadButton()
                 }
             }

--- a/Aidoku/Features/Manga/MangaView+ViewModel.swift
+++ b/Aidoku/Features/Manga/MangaView+ViewModel.swift
@@ -80,6 +80,19 @@ extension MangaView.ViewModel {
     }
 
     private func registerLibraryNotifications() {
+        NotificationCenter.default.publisher(for: .updateLibrary)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    guard let self else { return }
+                    await self.loadBookmarked()
+                    await self.checkForCategories()
+                    await self.loadHistory()
+                    self.chapters = self.filteredChapters()
+                    self.updateReadButton()
+                }
+            }
+            .store(in: &cancellables)
+
         NotificationCenter.default.publisher(for: .updateMangaDetails)
             .sink { [weak self] output in
                 Task { @MainActor in
@@ -856,7 +869,10 @@ extension MangaView.ViewModel {
         let nextChapter = getNextChapter()
         switch nextChapter {
             case .none:
-                return
+                self.nextChapter = nil
+                readingInProgress = false
+                allChaptersRead = false
+                allChaptersLocked = false
             case .allRead:
                 allChaptersRead = true
                 allChaptersLocked = false


### PR DESCRIPTION
## Summary

Changes coming from iCloud were imported into the database, but nothing told the interface about them, so the library, the manga view and the history list could keep showing stale data until they were reopened or refreshed manually. For example, adding a manga or reading a chapter on one device would not show up on another device that was already open.

The app now reacts to incoming sync changes as they land.

## Behavior

- The library, the manga view and the history list refresh on their own when a sync brings changes.
- The read button is recomputed, so a stale continue-reading target is no longer shown when there is nothing left to read.

## Verification

Verified with my own developer account and iCloud container on:

- MacBook Air M4, macOS 26.6.2 — Designed for iPad build
- iPhone 17, iOS 26.6.1 — debug build

- reading a chapter on one device updates the history page open on the other
- changing a manga's bookmark state on one device updates the library page on the other
- with the same manga open on both devices, changing the bookmark state on one side updates the other
- with the same manga open on both devices, marking a chapter as read on one side updates the other

## Test

- [x] builds and runs as a Designed for iPad build on my Mac
- [x] builds and runs on my iPhone
- [x] SwiftLint passes

## Demo

https://github.com/user-attachments/assets/c6836d81-3d44-4350-a56c-2da1e789a25e

https://github.com/user-attachments/assets/eff2b935-ff33-4cb7-aa01-d4dfb143b34e

https://github.com/user-attachments/assets/cd88ee73-3d0c-4360-9a4f-d60f462c3bb2
